### PR TITLE
feat(flock): Enable Users to Add Private Friends via FriendPage

### DIFF
--- a/Flock.xcodeproj/project.pbxproj
+++ b/Flock.xcodeproj/project.pbxproj
@@ -838,7 +838,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = lammylol.Flock;
+				PRODUCT_BUNDLE_IDENTIFIER = com.flockus.flock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -886,7 +886,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				ONLY_ACTIVE_ARCH = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = lammylol.Flock;
+				PRODUCT_BUNDLE_IDENTIFIER = com.flockus.flock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Flock.xcodeproj/project.pbxproj
+++ b/Flock.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		7A3158ED2AF357F5009B6E59 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3158EC2AF357F5009B6E59 /* SignInView.swift */; };
 		7A3440832C5ABE6E0041156F /* ContactRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3440822C5ABE6E0041156F /* ContactRow.swift */; };
 		7A3440862C5ABE790041156F /* FriendsPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3440842C5ABE790041156F /* FriendsPageView.swift */; };
+		7A362D4A2C8E14200010A12B /* TagModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A362D492C8E14200010A12B /* TagModel.swift */; };
 		7A416B7B2AFC71CB00249BB3 /* UIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A416B7A2AFC71CA00249BB3 /* UIHelper.swift */; };
 		7A4986662BCDCBFD00C0A936 /* PasswordChangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4986652BCDCBFD00C0A936 /* PasswordChangeView.swift */; };
 		7A4986682BCE2AE200C0A936 /* FeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4986672BCE2AE200C0A936 /* FeedViewModel.swift */; };
@@ -101,6 +102,7 @@
 		7A3158EC2AF357F5009B6E59 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
 		7A3440822C5ABE6E0041156F /* ContactRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactRow.swift; sourceTree = "<group>"; };
 		7A3440842C5ABE790041156F /* FriendsPageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FriendsPageView.swift; sourceTree = "<group>"; };
+		7A362D492C8E14200010A12B /* TagModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagModel.swift; sourceTree = "<group>"; };
 		7A416B7A2AFC71CA00249BB3 /* UIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIHelper.swift; sourceTree = "<group>"; };
 		7A4986652BCDCBFD00C0A936 /* PasswordChangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordChangeView.swift; sourceTree = "<group>"; };
 		7A4986672BCE2AE200C0A936 /* FeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModel.swift; sourceTree = "<group>"; };
@@ -264,6 +266,7 @@
 				7A4986672BCE2AE200C0A936 /* FeedViewModel.swift */,
 				E0564A092BB379DE00D21DB3 /* Tab.swift */,
 				7A7C84602BF4231E00E810B2 /* Privacy.swift */,
+				7A362D492C8E14200010A12B /* TagModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -613,6 +616,7 @@
 				7A4F26302AD0D2B600FB086C /* DateScroller.swift in Sources */,
 				7A3158ED2AF357F5009B6E59 /* SignInView.swift in Sources */,
 				7AE46BD52B10100D0034DAD6 /* Person.swift in Sources */,
+				7A362D4A2C8E14200010A12B /* TagModel.swift in Sources */,
 				7AB4DF5F2C641E2100CC3C67 /* debounceTextModel.swift in Sources */,
 				3ABC0ABF2C517533000AFFD1 /* CalendarService.swift in Sources */,
 				7A5C72352AFF5E3100A75636 /* Post.swift in Sources */,

--- a/Flock/Model/Person.swift
+++ b/Flock/Model/Person.swift
@@ -18,7 +18,10 @@ struct Person: Identifiable, Hashable {
         firstName + " " + lastName
     }
     var isPublic: Bool {
-        username != ""
+        friendState != "private"
+    }
+    var isPrivateFriend: Bool {
+        friendState == "private"
     }
     var friendState: String = String()
 //    var prayerCalendarInd: Bool = false

--- a/Flock/Model/TagModel.swift
+++ b/Flock/Model/TagModel.swift
@@ -1,0 +1,44 @@
+//
+//  TagModel.swift
+//  Flock
+//
+//  Created by Matt Lam on 9/8/24.
+//
+
+import SwiftUI
+
+struct tagModelView: View {
+    var textLabel: String
+    var systemImage: String = ""
+    var textSize: CGFloat
+    var foregroundColor: Color
+    var backgroundColor: Color
+    var opacity: CGFloat = 1.00
+    var boldBool: Bool = true
+    
+    var body: some View {
+        HStack {
+            if boldBool {
+                Text(textLabel)
+                    .font(.system(size: textSize))
+                    .bold()
+            } else {
+                Text(textLabel)
+                    .font(.system(size: textSize))
+            }
+            if systemImage != "" {
+                Image(systemName: systemImage)
+                    .imageScale(.small)
+                    .padding([.horizontal], -3)
+            }
+        }
+        .padding([.vertical], 5)
+        .padding([.horizontal], 10)
+        .background {
+            RoundedRectangle(cornerRadius: 5)
+                .fill(backgroundColor)
+                .opacity(opacity)
+        }
+        .foregroundStyle(foregroundColor)
+    }
+}

--- a/Flock/Services/FriendRequestListener.swift
+++ b/Flock/Services/FriendRequestListener.swift
@@ -12,6 +12,7 @@ import FirebaseFirestore
     private var friendRequestListener: ListenerRegistration?
     var pendingFriendRequests: [Person] = []
     var acceptedFriendRequests: [Person] = []
+    var privateFriends: [Person] = []
     
     func setUpListener(userID: String) async {
         let db = Firestore.firestore()
@@ -30,6 +31,7 @@ import FirebaseFirestore
                 
                 var newPendingFriendRequests: [Person] = []
                 var newAcceptedFriendRequests: [Person] = []
+                var newPrivateFriends: [Person] = []
                 
                 for document in documents {
                     if document.exists {
@@ -46,6 +48,8 @@ import FirebaseFirestore
                             newPendingFriendRequests.append(person)
                         } else if state == "approved" {
                             newAcceptedFriendRequests.append(person)
+                        } else if state == "private" {
+                            newPrivateFriends.append(person)
                         }
                     }
                 }
@@ -56,6 +60,10 @@ import FirebaseFirestore
                 
                 if newAcceptedFriendRequests != self.acceptedFriendRequests {
                     self.acceptedFriendRequests = newAcceptedFriendRequests
+                }
+                
+                if newPrivateFriends != self.privateFriends {
+                    self.privateFriends = newPrivateFriends
                 }
             }
         print("FriendsListener turned on.")

--- a/Flock/Services/UserService.swift
+++ b/Flock/Services/UserService.swift
@@ -41,8 +41,9 @@ class UserService { // Functions related to user information
         var lastName = person.lastName
         var friendState = person.friendState
         
-        if !person.isPublic { // If the username is empty, this person was 'created' by the user, so retrieve user's userID.
+        if !person.isPublic || person.userID == userHolder.person.userID { // If the username is empty, this person was 'created' by the user, so retrieve user's userID.
             userID = userHolder.person.userID
+            friendState = "private"
         } else { // If username exists, then request user document from firestore off of the username.
             do {
                 let ref = try await db.collection("users").document(userHolder.person.userID).collection("friendsList").whereField("username", isEqualTo: person.username).getDocuments()

--- a/Flock/Services/UserService.swift
+++ b/Flock/Services/UserService.swift
@@ -12,7 +12,7 @@ import FirebaseAuth
 class UserService { // Functions related to user information
     let db = Firestore.firestore() // initiaties Firestore
     
-    func getUserInfo(userID: String) async throws -> Person {
+    func getBasicUserInfo(userID: String) async throws -> Person {
         // get user information and save it to userHolder.person
         var person = Person()
         
@@ -34,31 +34,32 @@ class UserService { // Functions related to user information
         return person
     }
     
-    func retrieveUserInfoFromUsername(person: Person, userHolder: UserProfileHolder) async throws -> Person {
+    func retrieveUserInfoFromUserID(person: Person, userHolder: UserProfileHolder) async throws -> Person {
         // This function takes in a person object and returns additional information about the person. ie. if a user is accessing a profile for a username, this will retrieve information needed to fetch their data.
         var userID = person.userID
         var firstName = person.firstName
         var lastName = person.lastName
         var friendState = person.friendState
-        
-        if !person.isPublic || person.userID == userHolder.person.userID { // If the username is empty, this person was 'created' by the user, so retrieve user's userID.
+    
+        if person.isPrivateFriend || person.username == "" { // If the username is empty, this person was 'created' by the user, so retrieve user's userID.
             userID = userHolder.person.userID
             friendState = "private"
         } else { // If username exists, then request user document from firestore off of the username.
             do {
-                let ref = try await db.collection("users").document(userHolder.person.userID).collection("friendsList").whereField("username", isEqualTo: person.username).getDocuments()
+//                let ref = try await db.collection("users").document(userHolder.person.userID).collection("friendsList").whereField("username", isEqualTo: person.username).getDocuments()
+                let document = try await db.collection("users").document(userHolder.person.userID).collection("friendsList").document(person.userID).getDocument()
                 
-                for document in ref.documents {
-                    print(document.documentID)
-                    if document.exists {
-                        userID = document.get("userID") as? String ?? ""
-                        firstName = document.get("firstName") as? String ?? ""
-                        lastName = document.get("lastName") as? String ?? ""
-                        friendState = document.get("state") as? String ?? ""
-                    } else {
-                        throw PrayerPersonRetrievalError.noUsername
-                    }
+//                for document in ref.documents {
+//                    print(document.documentID)
+                if document.exists {
+                    userID = document.get("userID") as? String ?? ""
+                    firstName = document.get("firstName") as? String ?? ""
+                    lastName = document.get("lastName") as? String ?? ""
+                    friendState = document.get("state") as? String ?? ""
+                } else {
+                    throw PrayerPersonRetrievalError.noUsername
                 }
+//                }
             } catch {
                 print("Error getting document: \(error)")
             }

--- a/Flock/Views/Main Views/Calendar View/PrayerNameInputView.swift
+++ b/Flock/Views/Main Views/Calendar View/PrayerNameInputView.swift
@@ -138,7 +138,7 @@ struct PrayerNameInputView: View {
             
             if !usernameOrName.contains("/") {
                 do {
-                    try await userService.retrieveUserInfoFromUsername(person: Person(username: usernameOrName), userHolder: userHolder)
+                    try await userService.retrieveUserInfoFromUserID(person: Person(username: usernameOrName), userHolder: userHolder)
                 } catch PrayerPersonRetrievalError.noUsername {
                     saved = "\(String(usernameOrName.split(separator: "/").first ?? "")) has not been added as a friend yet. Please add them first as a friend before adding them to your calendar."
                 } catch {

--- a/Flock/Views/Main Views/ContentView.swift
+++ b/Flock/Views/Main Views/ContentView.swift
@@ -32,18 +32,18 @@ struct ContentView: View {
                         .imageScale(.large)
                     Text("Friends")
                 }.tag(2)
-            PrayerCalendarView()
-                .tabItem {
-                    Image(systemName: "calendar")
-                        .imageScale(.large)
-                    Text("Calendar")
-                }.tag(3)
+//            PrayerCalendarView()
+//                .tabItem {
+//                    Image(systemName: "calendar")
+//                        .imageScale(.large)
+//                    Text("Calendar")
+//                }.tag(3)
             ProfileView(person: userHolder.person)
                 .tabItem {
                     Image(systemName: "person.circle")
                         .imageScale(.large)
                     Text("Profile")
-                }.tag(4)
+                }.tag(3)
         }
         .onChange(of: scenePhase) { 
             oldPhase, newPhase in

--- a/Flock/Views/Main Views/Friends View/AddFriendPage.swift
+++ b/Flock/Views/Main Views/Friends View/AddFriendPage.swift
@@ -93,7 +93,6 @@ struct AddFriendPage: View {
                             Button {
                                 addPublicFriend(username: debounceModel.username)
                             } label: {
-                                Text(!debounceModel.validated && firstName != "" ? "Create a Profile" : "Request Friend")
                                 Text("Request Friend")
                                     .bold()
                                     .frame(maxWidth: .infinity)
@@ -297,7 +296,7 @@ struct AddFriendPage: View {
     
     func addPrivateFriend(firstName: String, lastName: String) {
         Task {
-            try await friendService.addPrivateFriend(firstName: firstName, lastName: lastName, user: userHolder.person)
+            try await friendService.addPrivateFriend(firstName: firstName.lowercased(), lastName: lastName.lowercased(), user: userHolder.person)
             privateConfirmation = true
         }
     }

--- a/Flock/Views/Main Views/Friends View/AddFriendPage.swift
+++ b/Flock/Views/Main Views/Friends View/AddFriendPage.swift
@@ -181,10 +181,9 @@ struct AddFriendPage: View {
                             }
                             .background(
                                 RoundedRectangle(cornerRadius: 15)
-                                    .stroke(Color.blue, lineWidth: 1)
+                                    .stroke(colorScheme == .dark ? Color.white : Color.blue, lineWidth: 1)
                                     .fill(Color.clear)
                                     .frame(height: 50)
-                                //                                .border(Color.blue)
                             )
                         }
                         .frame(maxWidth: .infinity)
@@ -242,7 +241,6 @@ struct AddFriendPage: View {
             .navigationTitle("Add Friend")
             .navigationBarTitleDisplayMode(.large)
             .navigationBarBackButtonHidden(true)
-            .ignoresSafeArea(.keyboard)
             .padding(.horizontal, 20)
         }
     }

--- a/Flock/Views/Main Views/Friends View/AddFriendPage.swift
+++ b/Flock/Views/Main Views/Friends View/AddFriendPage.swift
@@ -178,6 +178,7 @@ struct AddFriendPage: View {
                                 Text("Create Friend")
                                     .bold()
                                     .frame(maxWidth: .infinity)
+                                    .foregroundStyle(colorScheme == .dark ? Color.white : Color.blue)
                             }
                             .background(
                                 RoundedRectangle(cornerRadius: 15)

--- a/Flock/Views/Main Views/Friends View/AddFriendPage.swift
+++ b/Flock/Views/Main Views/Friends View/AddFriendPage.swift
@@ -17,6 +17,7 @@ struct AddFriendPage: View {
     @State private var errorAlert: Bool = false
     @State private var errorType: AddFriendError?
     @State private var confirmation: Bool = false
+    @State private var privateConfirmation: Bool = false
     @FocusState private var focus: Bool
     
     var friendService = FriendService()
@@ -26,140 +27,174 @@ struct AddFriendPage: View {
     
     var body: some View {
         NavigationStack{
-            VStack(alignment: .leading, spacing: 15) {
-                Text("Let's add a friend!")
-                    .font(.system(size: 16))
-                    .padding(.top, 40)
-                    .padding(.bottom, 5)
-                
-                ZStack { // for username
-                    Rectangle()
-                        .frame(height: 55)
-                        .foregroundStyle(.clear)
-                        .border(.secondary)
-                    
-                    TextField("Search a username", text: $debounceModel.username)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 55)
-                        .textInputAutocapitalization(.never)
-                        .offset(x: 40)
-                    
-                    HStack {
-                        Text("Username")
-                            .padding(.horizontal, 7)
-                            .font(.system(size: 14))
-                            .background {
-                                Rectangle().fill(.background)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 15) {
+                    // Public Friend - Search by Username
+                    Group {
+                        Text("Add a friend by searching by their username.")
+                            .font(.system(size: 16))
+                            .padding(.top, 30)
+                            .padding(.bottom, 5)
+                        
+                        ZStack { // for username
+                            Rectangle()
+                                .frame(height: 55)
+                                .foregroundStyle(.clear)
+                                .border(.secondary)
+                            
+                            TextField("Search a username", text: $debounceModel.username)
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 55)
+                                .textInputAutocapitalization(.never)
+                                .offset(x: 40)
+                            
+                            HStack {
+                                Text("Username")
+                                    .padding(.horizontal, 7)
+                                    .font(.system(size: 14))
+                                    .background {
+                                        Rectangle().fill(.background)
+                                    }
+                                    .offset(x: 8, y: -27)
+                                Spacer()
                             }
-                            .offset(x: 8, y: -27)
-                        Spacer()
-                    }
-                    HStack {
-                        Image(systemName: "magnifyingglass")
-                        Spacer()
-                    }
-                    .offset(x: 15)
-                }
-                
-                VStack {
-                    if !debounceModel.validated && debounceModel.username != "" {
+                            HStack {
+                                Image(systemName: "magnifyingglass")
+                                Spacer()
+                            }
+                            .offset(x: 15)
+                        }
+                        
+                        VStack {
+                            if !debounceModel.validated && debounceModel.username != "" {
+                                HStack {
+                                    Text("No user found.")
+                                        .font(.system(size: 14))
+                                    Spacer()
+                                }
+                            } else if debounceModel.validated && debounceModel.username != "" {
+                                HStack {
+                                    Image(systemName: "checkmark")
+                                    Text("This account exists for **\(debounceModel.person.firstName.capitalized) \(debounceModel.person.lastName.capitalized)**")
+                                        .font(.system(size: 14))
+                                    Spacer()
+                                }
+                            } else {
+                                HStack {
+                                    Text("")
+                                }
+                            }// if none of the above, be empty. Need to fill up space
+                        }
+                        .frame(height: 12)
+                        .offset(y: -4)
+                        .padding(.bottom, 5)
+                        
                         HStack {
-                            Text("No user found.")
+                            Button {
+                                addPublicFriend(username: debounceModel.username)
+                            } label: {
+                                Text(!debounceModel.validated && firstName != "" ? "Create a Profile" : "Request Friend")
+                                Text("Request Friend")
+                                    .bold()
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .background(
+                                RoundedRectangle(cornerRadius: 15)
+                                    .fill(.blue)
+                                    .frame(height: 50)
+                            )
+                            .foregroundStyle(.white)
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    
+                    //              'Private Friend' Option.
+                    Group {
+                        VStack(alignment: .center) {
+                            Text("Or")
+                                .padding([.vertical], 30)
+                            
+                            Text("Create a Friend (Private)")
+                                .font(.title2)
+                                .padding(.bottom, 5)
+                            
+                            Text("This creates a private profile which allows you to track prayers for a friend who does not have an account. This is linked under your account, so no one will have access to them but you.")
                                 .font(.system(size: 14))
-                            Spacer()
+                                .padding(.bottom, 5)
                         }
-                    } else if debounceModel.validated && debounceModel.username != "" {
+                        
+                        ZStack { // for firstName
+                            Rectangle()
+                                .frame(height: 55)
+                                .foregroundStyle(.clear)
+                                .border(.secondary)
+                            
+                            TextField("First Name", text: $firstName)
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 55)
+                                .textInputAutocapitalization(.never)
+                                .offset(x: 15)
+                            
+                            HStack {
+                                Text("Name")
+                                    .padding(.horizontal, 7)
+                                    .font(.system(size: 14))
+                                    .background {
+                                        Rectangle().fill(.background)
+                                    }
+                                    .offset(x: 8, y: -27)
+                                Spacer()
+                            }
+                        }
+                        .padding(.bottom, 5)
+                        
+                        ZStack { // for lastName
+                            Rectangle()
+                                .frame(height: 55)
+                                .foregroundStyle(.clear)
+                                .border(.secondary)
+                            
+                            TextField("Last Name", text: $lastName)
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 55)
+                                .textInputAutocapitalization(.never)
+                                .offset(x: 15)
+                            
+                            HStack {
+                                Text("Name")
+                                    .padding(.horizontal, 7)
+                                    .font(.system(size: 14))
+                                    .background {
+                                        Rectangle().fill(.background)
+                                    }
+                                    .offset(x: 8, y: -27)
+                                Spacer()
+                            }
+                        }
+                        
                         HStack {
-                            Image(systemName: "checkmark")
-                            Text("This account exists for **\(debounceModel.person.firstName.capitalized) \(debounceModel.person.lastName.capitalized)**")
-                                .font(.system(size: 14))
-                            Spacer()
+                            Button {
+                                addPrivateFriend(firstName: firstName, lastName: lastName)
+                            } label: {
+                                Text("Create Friend")
+                                    .bold()
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .background(
+                                RoundedRectangle(cornerRadius: 15)
+                                    .stroke(Color.blue, lineWidth: 1)
+                                    .fill(Color.clear)
+                                    .frame(height: 50)
+                                //                                .border(Color.blue)
+                            )
                         }
-                    } else {
-                        HStack {
-                            Text("")
-                        }
-                    }// if none of the above, be empty. Need to fill up space
-                    Spacer()
-                }
-                .frame(height: 12)
-                .padding(.bottom, 5)
-                
-//                Removing 'Private Friend' Option for now.
-//                Text("You can create a private profile to pray for your friend that doesn’t have an account! Only you will be able to edit and view the prayer requests for this friend.")
-//                    .font(.system(size: 14))
-//                    .padding(.bottom, 5)
-//                
-//                ZStack { // for firstName
-//                    Rectangle()
-//                        .frame(height: 55)
-//                        .foregroundStyle(.clear)
-//                        .border(.secondary)
-//                    
-//                    TextField("First Name", text: $firstName)
-//                        .frame(maxWidth: .infinity)
-//                        .frame(height: 55)
-//                        .textInputAutocapitalization(.never)
-//                        .offset(x: 15)
-//                    
-//                    HStack {
-//                        Text("Name")
-//                            .padding(.horizontal, 7)
-//                            .font(.system(size: 14))
-//                            .background {
-//                                Rectangle().fill(.background)
-//                            }
-//                            .offset(x: 8, y: -27)
-//                        Spacer()
-//                    }
-//                }
-//                .padding(.bottom, 5)
-//                
-//                ZStack { // for lastName
-//                    Rectangle()
-//                        .frame(height: 55)
-//                        .foregroundStyle(.clear)
-//                        .border(.secondary)
-//                    
-//                    TextField("Last Name", text: $lastName)
-//                        .frame(maxWidth: .infinity)
-//                        .frame(height: 55)
-//                        .textInputAutocapitalization(.never)
-//                        .offset(x: 15)
-//                    
-//                    HStack {
-//                        Text("Name")
-//                            .padding(.horizontal, 7)
-//                            .font(.system(size: 14))
-//                            .background {
-//                                Rectangle().fill(.background)
-//                            }
-//                            .offset(x: 8, y: -27)
-//                        Spacer()
-//                    }
-//                }
-                
-                HStack {
-                    Button {
-                        addFriend(username: debounceModel.username)
-                    } label: {
-                        Text(!debounceModel.validated && firstName != "" ? "Create a Profile" : "Request Friend")
-                            .bold()
-                            .frame(maxWidth: .infinity)
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 20)
+                        .padding(.bottom, 10)
                     }
-                    .background(
-                        RoundedRectangle(cornerRadius: 15)
-                            .fill(.blue)
-                            .frame(height: 55)
-                    )
-                    .foregroundStyle(.white)
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.top, 10)
-                
-                Spacer()
             }
-            .alert(isPresented: .constant(errorAlert || confirmation)) {
+            .alert(isPresented: .constant(errorAlert || confirmation || privateConfirmation)) {
                 if errorAlert {
                     return Alert(
                         title: Text(errorType?.failureReason ?? "error"),
@@ -167,12 +202,22 @@ struct AddFriendPage: View {
                         dismissButton: .default(Text("OK")) {
                             errorAlert = false
                         })
-                } else {
+                } else if confirmation {
                     return Alert(
                         title: Text("Request Sent"),
                         message: Text("Your friend will appear in your list once the request has been approved."),
                         dismissButton: .default(Text("OK")) {
                             confirmation = false
+                            DispatchQueue.main.async {
+                                dismiss()
+                            }
+                        })
+                } else {
+                    return Alert(
+                        title: Text("Friend Created"),
+                        message: Text("You can now view their profile and start adding any existing prayer requests you would like to be praying for."),
+                        dismissButton: .default(Text("OK")) {
+                            privateConfirmation = false
                             DispatchQueue.main.async {
                                 dismiss()
                             }
@@ -196,13 +241,14 @@ struct AddFriendPage: View {
                 }
             }
             .navigationTitle("Add Friend")
+            .navigationBarTitleDisplayMode(.large)
             .navigationBarBackButtonHidden(true)
             .ignoresSafeArea(.keyboard)
             .padding(.horizontal, 20)
         }
     }
     
-    func addFriend(username: String) {
+    func addPublicFriend(username: String) {
         Task {
             do {
                 if username != "" { // functions only if the username exists (aka profile is public)
@@ -246,6 +292,13 @@ struct AddFriendPage: View {
                 errorAlert = true
                 self.errorType = nil
             }
+        }
+    }
+    
+    func addPrivateFriend(firstName: String, lastName: String) {
+        Task {
+            try await friendService.addPrivateFriend(firstName: firstName, lastName: lastName, user: userHolder.person)
+            privateConfirmation = true
         }
     }
     

--- a/Flock/Views/Main Views/Friends View/ContactRow.swift
+++ b/Flock/Views/Main Views/Friends View/ContactRow.swift
@@ -26,12 +26,15 @@ struct ContactRow: View {
                 
                 VStack(alignment: .leading) {
                     HStack {
-                        Text("\(person.firstName) \(person.lastName)")
+                        Text("\(person.firstName.capitalized) \(person.lastName.capitalized)")
                             .font(.system(size: 20))
                             .bold()
                         if person.isPublic && person.friendState != "pending" {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(.blue)
+                        } else if !person.isPublic {
+                            Image(systemName: "lock.icloud.fill")
+                                .foregroundStyle(colorScheme == .dark ? .white : .black )
                         }
                         Spacer()
                         
@@ -90,15 +93,11 @@ struct ContactRow: View {
                             .foregroundStyle(colorScheme == .dark ? .white : .black)
                             .buttonStyle(PlainButtonStyle())
                         } else {
-                            Text(person.isPublic ? "Public Account" : "Private")
-                                .padding([.vertical], 3)
-                                .padding([.horizontal], 20)
-                                .font(.system(size: 16))
-                                .background {
-                                    RoundedRectangle(cornerRadius: 5)
-                                        .fill(.gray)
-                                        .opacity(0.30)
-                                }
+                            if person.isPublic {
+                                tagModelView(textLabel: "Public Account", systemImage: "", textSize: 16, foregroundColor: colorScheme == .dark ? .white : .black, backgroundColor: .gray, opacity: 0.30, boldBool: false)
+                            } else {
+                                tagModelView(textLabel: "Private Account", systemImage: "", textSize: 16, foregroundColor: colorScheme == .dark ? .white : .black, backgroundColor: .gray, opacity: 0.30, boldBool: false)
+                            }
                         }
                         Spacer()
                     }

--- a/Flock/Views/Main Views/Friends View/FriendsPageView.swift
+++ b/Flock/Views/Main Views/Friends View/FriendsPageView.swift
@@ -121,7 +121,7 @@ struct FriendsPageView: View {
                 }
                 .searchable(text: $search, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search friends")
                 .overlay {
-                    if friendRequestListener.acceptedFriendRequests.isEmpty && friendRequestListener.pendingFriendRequests.isEmpty {
+                    if friendRequestListener.acceptedFriendRequests.isEmpty && friendRequestListener.pendingFriendRequests.isEmpty && friendRequestListener.privateFriends.isEmpty {
                             VStack{
                                 ContentUnavailableView {
                                     Label("No Friends...Yet!", systemImage: "person.crop.square")

--- a/Flock/Views/Main Views/Friends View/FriendsPageView.swift
+++ b/Flock/Views/Main Views/Friends View/FriendsPageView.swift
@@ -144,20 +144,9 @@ struct FriendsPageView: View {
                 .padding(.horizontal, 17)
                 .padding(.bottom, 15)
             }
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        showAddFriend.toggle()
-                    } label: {
-                        Image(systemName: "plus.circle")
-                    }
-                }
-            }
             .sheet(isPresented: $showAddFriend) {
                 AddFriendPage(preName: search)
             }
-            .navigationTitle("Friends")
-            .navigationBarTitleDisplayMode(.automatic)
             .refreshable(action: {
                 Task {
                     do {
@@ -170,6 +159,17 @@ struct FriendsPageView: View {
                 }
             })
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .navigationTitle("Friends")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showAddFriend.toggle()
+                    } label: {
+                        Image(systemName: "plus.circle")
+                    }
+                }
+            }
         }
         .background(.windowBackground)
         .scrollContentBackground(.hidden)

--- a/Flock/Views/Main Views/Prayer Feed View/PostsFeed.swift
+++ b/Flock/Views/Main Views/Prayer Feed View/PostsFeed.swift
@@ -28,7 +28,7 @@ struct PostsFeed: View {
                 LazyVStack {
                     ForEach($viewModel.prayerRequests) { $prayerRequest in
                         VStack {
-                            PostRow(viewModel: viewModel, post: $prayerRequest)
+                            PostRow(viewModel: viewModel, post: $prayerRequest, person: person)
                             Rectangle()
                                 .frame(height: 4)
                                 .foregroundStyle(.bar)
@@ -49,9 +49,7 @@ struct PostsFeed: View {
                     do {
                         userHolder.profileViewIsLoading = true
                         defer { userHolder.profileViewIsLoading = false }
-                        
-                        person = try await userService.retrieveUserInfoFromUsername(person: person, userHolder: userHolder) // repetitive. Need to refactor later.
-                        
+
                         if person.friendState == "sent" || person.friendState == "pending" {
                             return
                         }
@@ -141,7 +139,7 @@ struct PostsFeed: View {
         .sheet(isPresented: $showSubmit, onDismiss: {
             Task {
                 do {
-                    self.person = try await userService.retrieveUserInfoFromUsername(person: person, userHolder: userHolder)
+                    self.person = try await userService.retrieveUserInfoFromUserID(person: person, userHolder: userHolder)
                     
                     if !viewModel.isFetching || !viewModel.isLoading {
                         await viewModel.getPrayerRequests(user: userHolder.person, person: person)

--- a/Flock/Views/Main Views/Prayer Feed View/PostsFeed.swift
+++ b/Flock/Views/Main Views/Prayer Feed View/PostsFeed.swift
@@ -46,18 +46,11 @@ struct PostsFeed: View {
         .task {
             if viewModel.prayerRequests.isEmpty {
                 if !viewModel.isFetching || !viewModel.isLoading {
-                    do {
-                        userHolder.profileViewIsLoading = true
-                        defer { userHolder.profileViewIsLoading = false }
-
-                        if person.friendState == "sent" || person.friendState == "pending" {
-                            return
-                        }
-                        await viewModel.getPrayerRequests(user: userHolder.person, person: person)
-                        self.viewModel.prayerRequests = viewModel.prayerRequests
-                    } catch {
-                        print(error)
+                    if person.friendState == "sent" || person.friendState == "pending" {
+                        return
                     }
+                    await viewModel.getPrayerRequests(user: userHolder.person, person: person)
+                    self.viewModel.prayerRequests = viewModel.prayerRequests
                 }
             }
         }

--- a/Flock/Views/Main Views/Prayer Feed View/PostsFeed.swift
+++ b/Flock/Views/Main Views/Prayer Feed View/PostsFeed.swift
@@ -11,6 +11,7 @@ struct PostsFeed: View {
     
     @State var viewModel: FeedViewModel
     @Environment(UserProfileHolder.self) var userHolder
+    @Environment(\.colorScheme) var colorScheme
     @Binding var person: Person
     @State var profileOrFeed: String = "feed"
     @State private var showSubmit: Bool = false
@@ -19,6 +20,8 @@ struct PostsFeed: View {
     
     var body: some View {
         ZStack {
+            (colorScheme == .dark ? Color.black : Color.white).ignoresSafeArea() // sets background color.
+                
             if viewModel.isLoading/* && !userHolder.refresh*/ {
                 ProgressView()
             } else {

--- a/Flock/Views/Main Views/Prayer Feed View/PrivacyView.swift
+++ b/Flock/Views/Main Views/Prayer Feed View/PrivacyView.swift
@@ -15,7 +15,7 @@ struct PrivacyView: View {
     
     var body: some View {
         Menu {
-            if person.username != "" && person.userID == userHolder.person.userID { // this would mean this is your own profile. You should only be able to set public and private settings for your own prayer requests.
+            if person.isPrivateFriend { // this would mean this is your own profile. You should only be able to set public and private settings for your own prayer requests.
                 ForEach(privacyOptions) { privacy in
                     Button {
                         privacySetting = privacy.statusKey

--- a/Flock/Views/Main Views/Prayer Feed View/PrivacyView.swift
+++ b/Flock/Views/Main Views/Prayer Feed View/PrivacyView.swift
@@ -15,7 +15,7 @@ struct PrivacyView: View {
     
     var body: some View {
         Menu {
-            if person.isPrivateFriend { // this would mean this is your own profile. You should only be able to set public and private settings for your own prayer requests.
+            if person.isPublic { // this would mean this is your own profile. You should only be able to set public and private settings for your own prayer requests.
                 ForEach(privacyOptions) { privacy in
                     Button {
                         privacySetting = privacy.statusKey

--- a/Flock/Views/Main Views/Profile View/ProfileView.swift
+++ b/Flock/Views/Main Views/Profile View/ProfileView.swift
@@ -140,6 +140,9 @@ struct ProfileView: View {
                 }
                 .task {
                     do {
+                        userHolder.profileViewIsLoading = true // sets variable so no 'tag' shows until task has run.
+                        defer { userHolder.profileViewIsLoading = false }
+
                         person = try await userService.retrieveUserInfoFromUserID(person: person, userHolder: userHolder) // repetitive. Need to refactor later.
                     } catch {
                         print(error)

--- a/Flock/Views/Main Views/Profile View/ProfileView.swift
+++ b/Flock/Views/Main Views/Profile View/ProfileView.swift
@@ -31,7 +31,9 @@ struct ProfileView: View {
     var body: some View {
         NavigationStack(path: $navigationPath) {
             ZStack {
-                (colorScheme == .dark ? Color.black : Color.white).ignoresSafeArea() // sets background color.
+//                (colorScheme == .light ? Color(.systemGray6) : .clear)
+//                    .ignoresSafeArea()
+                 // sets background color.
                 
                 ScrollView {
                     VStack(alignment: .leading) {

--- a/Flock/Views/Main Views/Profile View/ProfileView.swift
+++ b/Flock/Views/Main Views/Profile View/ProfileView.swift
@@ -30,173 +30,180 @@ struct ProfileView: View {
     
     var body: some View {
         NavigationStack(path: $navigationPath) {
-            ScrollView {
-                VStack(alignment: .leading) {
+            ZStack {
+                (colorScheme == .dark ? Color.black : Color.white).ignoresSafeArea() // sets background color.
+                
+                ScrollView {
                     VStack(alignment: .leading) {
-                        Group {
-                            if person.username == "" {
-                                Text("@\(userHolder.person.username)")
-                            } else {
-                                Text("@\(person.username)")
-                            }
-                        }
-                        .font(.system(size: 14))
-                        .padding(.top, -8)
-                        
-                        if !userHolder.profileViewIsLoading {
+                        VStack(alignment: .leading) {
                             Group {
-                                // Button to show friend state. If friend state is pending, give option to approve or decline. Currently: Can't view a profile if you didn't add.
-                                if person.friendState == "pending" {
-                                    Menu {
-                                        Button {
-                                            acceptFriendRequest()
-                                        } label: {
-                                            Label("Approve Request", systemImage: "person.crop.circle.badge.plus")
-                                        }
-                                        Button {
-                                            dismissFriendRequest()
-                                        } label: {
-                                            Label("Dismiss Request", systemImage: "xmark.circle")
-                                        }
-                                    } label: {
-                                        tagModelView(textLabel: "Respond to Friend Request", systemImage: "arrowtriangle.down.circle.fill", textSize: 14, foregroundColor: .white, backgroundColor: .blue)
-                                            .buttonStyle(PlainButtonStyle())
-                                    }
-                                } else if person.friendState == "approved" {
-                                    tagModelView(textLabel: "Friends", systemImage: "checkmark.circle.fill", textSize: 14, foregroundColor: colorScheme == .dark ? .white : .black, backgroundColor: .gray, opacity: 0.30)
-                                } else if person.friendState == "sent" {
-                                    tagModelView(textLabel: "Pending", systemImage: "", textSize: 14, foregroundColor: .black, backgroundColor: .gray, opacity: 0.30)
-                                } else if person.friendState == "private" {
-                                    tagModelView(textLabel: "Private", systemImage: "lock.icloud.fill", textSize: 14, foregroundColor: .black, backgroundColor: .gray, opacity: 0.30)
-                                } else if person.isPublic && person.username != userHolder.person.username && person.friendState == "" {
-                                   Button {
-                                       addFriend()
-                                   } label: {
-                                       tagModelView(textLabel: "Add Friend", textSize: 14, foregroundColor: .white, backgroundColor: .blue)
-                                   }
-                                }
-                            }
-                            .padding(.top, 3)
-                        } else if person.username != userHolder.person.username {
-                            tagModelView(textLabel: "T", textSize: 14, foregroundColor: .clear, backgroundColor: .clear)
-                            .padding(.top, 3)
-                            // blanket clear background to make sure the height gets set while loading friend status.
-                        }
-                    }
-                    .padding([.leading, .trailing], 20)
-                    
-                    Spacer()
-                    
-                    LazyVStack {
-                        HStack{
-                            // Only show this if you are the owner of profile.
-                            if person.username == userHolder.person.username {
-                                Text("My Posts")
-                                    .font(.title3)
-                                    .bold()
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.leading, 20)
-                            } else {
-                                Text("\(person.firstName)'s Posts")
-                                    .font(.title3)
-                                    .bold()
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.leading, 20)
-                            }
-                            Spacer()
-                            
-                            HStack {
-                                if viewModel.selectedStatus == .noLongerNeeded {
-                                    Text("No Longer\nNeeded")
-                                        .font(.system(size: 14))
-                                        .multilineTextAlignment(.trailing)
+                                if person.username == "" {
+                                    Text("@\(userHolder.person.username)")
                                 } else {
-                                    Text(viewModel.selectedStatus.rawValue.capitalized)
-                                        .font(.system(size: 16))
-                                        .multilineTextAlignment(.trailing)
+                                    Text("@\(person.username)")
                                 }
-                                
-                                StatusPicker(viewModel: viewModel)
-                                    .onChange(of: viewModel.selectedStatus, {
-                                        Task {
-                                            if !viewModel.isFetching || !viewModel.isLoading {
-                                                await viewModel.getPrayerRequests(user: userHolder.person, person: person)
-                                            }
-                                        }
-                                    })
                             }
-                            .padding(.trailing, 20)
+                            .font(.system(size: 14))
+                            .padding(.top, -8)
+                            
+                            if !userHolder.profileViewIsLoading {
+                                Group {
+                                    // Button to show friend state. If friend state is pending, give option to approve or decline. Currently: Can't view a profile if you didn't add.
+                                    if person.friendState == "pending" {
+                                        Menu {
+                                            Button {
+                                                acceptFriendRequest()
+                                            } label: {
+                                                Label("Approve Request", systemImage: "person.crop.circle.badge.plus")
+                                            }
+                                            Button {
+                                                dismissFriendRequest()
+                                            } label: {
+                                                Label("Dismiss Request", systemImage: "xmark.circle")
+                                            }
+                                        } label: {
+                                            tagModelView(textLabel: "Respond to Friend Request", systemImage: "arrowtriangle.down.circle.fill", textSize: 14, foregroundColor: .white, backgroundColor: .blue)
+                                                .buttonStyle(PlainButtonStyle())
+                                        }
+                                    } else if person.friendState == "approved" {
+                                        tagModelView(textLabel: "Friends", systemImage: "checkmark.circle.fill", textSize: 14, foregroundColor: colorScheme == .dark ? .white : .black, backgroundColor: .gray, opacity: 0.30)
+                                    } else if person.friendState == "sent" {
+                                        tagModelView(textLabel: "Pending", systemImage: "", textSize: 14, foregroundColor: .black, backgroundColor: .gray, opacity: 0.30)
+                                    } else if person.friendState == "private" {
+                                        tagModelView(textLabel: "Private", systemImage: "lock.icloud.fill", textSize: 14, foregroundColor: colorScheme == .dark ? .white : .black, backgroundColor: .gray, opacity: 0.30)
+                                    } else if person.isPublic && person.username != userHolder.person.username && person.friendState == "" {
+                                        Button {
+                                            addFriend()
+                                        } label: {
+                                            tagModelView(textLabel: "Add Friend", textSize: 14, foregroundColor: .white, backgroundColor: .blue)
+                                        }
+                                    }
+                                }
+                                .padding(.top, 3)
+                            } else if person.username != userHolder.person.username {
+                                tagModelView(textLabel: "T", textSize: 14, foregroundColor: .clear, backgroundColor: .clear)
+                                    .padding(.top, 3)
+                                // blanket clear background to make sure the height gets set while loading friend status.
+                            }
                         }
-                        Divider()
-                        PostsFeed(viewModel: viewModel, person: $person, profileOrFeed: "profile") //person is binding so it updates when parent view updates.
+                        .padding([.leading, .trailing], 20)
+                        
+                        Spacer()
+                        
+                        LazyVStack {
+                            HStack{
+                                // Only show this if you are the owner of profile.
+                                if person.username == userHolder.person.username {
+                                    Text("My Posts")
+                                        .font(.title3)
+                                        .bold()
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .padding(.leading, 20)
+                                } else {
+                                    Text("\(person.firstName)'s Posts")
+                                        .font(.title3)
+                                        .bold()
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .padding(.leading, 20)
+                                }
+                                Spacer()
+                                
+                                HStack {
+                                    if viewModel.selectedStatus == .noLongerNeeded {
+                                        Text("No Longer\nNeeded")
+                                            .font(.system(size: 14))
+                                            .multilineTextAlignment(.trailing)
+                                    } else {
+                                        Text(viewModel.selectedStatus.rawValue.capitalized)
+                                            .font(.system(size: 16))
+                                            .multilineTextAlignment(.trailing)
+                                    }
+                                    
+                                    StatusPicker(viewModel: viewModel)
+                                        .onChange(of: viewModel.selectedStatus, {
+                                            Task {
+                                                if !viewModel.isFetching || !viewModel.isLoading {
+                                                    await viewModel.getPrayerRequests(user: userHolder.person, person: person)
+                                                }
+                                            }
+                                        })
+                                }
+                                .padding(.trailing, 20)
+                            }
+                            Divider()
+                            PostsFeed(viewModel: viewModel, person: $person, profileOrFeed: "profile") //person is binding so it updates when parent view updates.
+                        }
+                        .padding(.top, 10)
                     }
-                    .padding(.top, 10)
                 }
-            }
-            .refreshable {
-                Task {
-                    if viewModel.isFinished {
-                        await viewModel.getPrayerRequests(user: userHolder.person, person: person)
-                    }
-                }
-            }
-            .navigationTitle(person.firstName.capitalized + " " + person.lastName.capitalized)
-            .navigationBarTitleDisplayMode(.large)
-            .sheet(isPresented: $showSubmit, onDismiss: {
-                Task {
-                    do {
-                        if viewModel.prayerRequests.isEmpty || userHolder.refresh == true {
-                            self.person = try await userService.retrieveUserInfoFromUsername(person: person, userHolder: userHolder) // retrieve the userID from the username submitted only if username is not your own. Will return user's userID if there is a valid username. If not, will return user's own.
+                .refreshable {
+                    Task {
+                        if viewModel.isFinished {
                             await viewModel.getPrayerRequests(user: userHolder.person, person: person)
-                        } else {
-                            self.viewModel.prayerRequests = viewModel.prayerRequests
                         }
-                        print("Success retrieving prayer requests for \(person.userID)")
                     }
                 }
-            }, content: {
-                SubmitPostForm(person: person)
-            })
-            .toolbar {
-                // Only show this if the account has been created under your userID. Aka, can be your profile or another that you have created for someone.
-                if person.userID == userHolder.person.userID {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        if person.username == userHolder.person.username {
+                .navigationTitle(person.firstName.capitalized + " " + person.lastName.capitalized)
+                .navigationBarTitleDisplayMode(.large)
+                .sheet(isPresented: $showSubmit, onDismiss: {
+                    Task {
+                        do {
+                            if viewModel.prayerRequests.isEmpty || userHolder.refresh == true {
+                                //                            self.person = try await userService.retrieveUserInfoFromUsername(person: person, userHolder: userHolder)
+                                
+                                
+                                // retrieve the userID from the username submitted only if username is not your own. Will return user's userID if there is a valid username. If not, will return user's own.
+                                await viewModel.getPrayerRequests(user: userHolder.person, person: person)
+                            } else {
+                                self.viewModel.prayerRequests = viewModel.prayerRequests
+                            }
+                            print("Success retrieving prayer requests for \(person.userID)")
+                        }
+                    }
+                }, content: {
+                    SubmitPostForm(person: person)
+                })
+                .toolbar {
+                    // Only show this if the account has been created under your userID. Aka, can be your profile or another that you have created for someone.
+                    if person.userID == userHolder.person.userID {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            if person.username == userHolder.person.username {
+                                HStack {
+                                    Button(action: {
+                                        navigationPath.append("settings")
+                                    }) {
+                                        Image(systemName: "gear")
+                                    }
+                                }
+                                // temporary fix for Navigation Link not working.
+                                .padding(.trailing, -18)
+                                .padding(.top, 3)
+                            }
+                        }
+                        ToolbarItem(placement: .topBarTrailing) {
                             HStack {
                                 Button(action: {
-                                    navigationPath.append("settings")
+                                    showSubmit.toggle()
                                 }) {
-                                    Image(systemName: "gear")
+                                    Image(systemName: "square.and.pencil")
                                 }
                             }
-                            // temporary fix for Navigation Link not working.
-                            .padding(.trailing, -18)
-                            .padding(.top, 3)
-                        }
-                    }
-                    ToolbarItem(placement: .topBarTrailing) {
-                        HStack {
-                            Button(action: {
-                                showSubmit.toggle()
-                            }) {
-                                Image(systemName: "square.and.pencil")
-                            }
                         }
                     }
                 }
-            }
-            .navigationDestination(for: String.self) { value in
-                if value == "settings" {
-                    ProfileSettingsView()
+                .navigationDestination(for: String.self) { value in
+                    if value == "settings" {
+                        ProfileSettingsView()
+                    }
                 }
-            }
-            .alert(isPresented: $addFriendConfirmation) {
-                return Alert(
-                    title: Text("Request Sent"),
-                    message: Text("Your friend will appear in your list once the request has been approved."),
-                    dismissButton: .default(Text("OK")) {
-                        addFriendConfirmation = false
-                    })
+                .alert(isPresented: $addFriendConfirmation) {
+                    return Alert(
+                        title: Text("Request Sent"),
+                        message: Text("Your friend will appear in your list once the request has been approved."),
+                        dismissButton: .default(Text("OK")) {
+                            addFriendConfirmation = false
+                        })
+                }
             }
         }
     }

--- a/Flock/Views/Main Views/Profile View/ProfileView.swift
+++ b/Flock/Views/Main Views/Profile View/ProfileView.swift
@@ -138,6 +138,14 @@ struct ProfileView: View {
                         .padding(.top, 10)
                     }
                 }
+                .task {
+                    do {
+                        person = try await userService.retrieveUserInfoFromUserID(person: person, userHolder: userHolder) // repetitive. Need to refactor later.
+                    } catch {
+                        print(error)
+                    }
+                    
+                }
                 .refreshable {
                     Task {
                         if viewModel.isFinished {

--- a/Flock/Views/Main Views/Profile View/ProfileView.swift
+++ b/Flock/Views/Main Views/Profile View/ProfileView.swift
@@ -66,14 +66,14 @@ struct ProfileView: View {
                                     tagModelView(textLabel: "Friends", systemImage: "checkmark.circle.fill", textSize: 14, foregroundColor: colorScheme == .dark ? .white : .black, backgroundColor: .gray, opacity: 0.30)
                                 } else if person.friendState == "sent" {
                                     tagModelView(textLabel: "Pending", systemImage: "", textSize: 14, foregroundColor: .black, backgroundColor: .gray, opacity: 0.30)
-                                } else if person.isPublic && person.username != userHolder.person.username && person.friendState == "" {
-                                    Button {
-                                        addFriend()
-                                    } label: {
-                                        tagModelView(textLabel: "Add Friend", textSize: 14, foregroundColor: .white, backgroundColor: .blue)
-                                    }
-                                } else if !person.isPublic && person.friendState == "" {
+                                } else if person.friendState == "private" {
                                     tagModelView(textLabel: "Private", systemImage: "lock.icloud.fill", textSize: 14, foregroundColor: .black, backgroundColor: .gray, opacity: 0.30)
+                                } else if person.isPublic && person.username != userHolder.person.username && person.friendState == "" {
+                                   Button {
+                                       addFriend()
+                                   } label: {
+                                       tagModelView(textLabel: "Add Friend", textSize: 14, foregroundColor: .white, backgroundColor: .blue)
+                                   }
                                 }
                             }
                             .padding(.top, 3)
@@ -140,7 +140,7 @@ struct ProfileView: View {
                     }
                 }
             }
-            .navigationTitle(person.firstName + " " + person.lastName)
+            .navigationTitle(person.firstName.capitalized + " " + person.lastName.capitalized)
             .navigationBarTitleDisplayMode(.large)
             .sheet(isPresented: $showSubmit, onDismiss: {
                 Task {
@@ -233,36 +233,6 @@ struct ProfileView: View {
             return "private profile"
         }
         return "@\(person.username.capitalized)"
-    }
-}
-
-struct tagModelView: View {
-    var textLabel: String
-    var systemImage: String = ""
-    var textSize: CGFloat
-    var foregroundColor: Color
-    var backgroundColor: Color
-    var opacity: CGFloat = 1.00
-    
-    var body: some View {
-        HStack {
-            Text(textLabel)
-                .font(.system(size: textSize))
-                .bold()
-            if systemImage != "" {
-                Image(systemName: systemImage)
-                    .imageScale(.small)
-                    .padding([.horizontal], -3)
-            }
-        }
-        .padding([.vertical], 5)
-        .padding([.horizontal], 10)
-        .background {
-            RoundedRectangle(cornerRadius: 5)
-                .fill(backgroundColor)
-                .opacity(opacity)
-        }
-        .foregroundStyle(foregroundColor)
     }
 }
 

--- a/Flock/Views/Model Views/Post View/PostEditView.swift
+++ b/Flock/Views/Model Views/Post View/PostEditView.swift
@@ -14,7 +14,7 @@ struct PostEditView: View {
     @Environment(\.colorScheme) var colorScheme
     
     @State var prayerRequestUpdates: [PostUpdate] = []
-    var person: Person
+    @State var person: Person
     @State var post: Post
     @State var showAddUpdateView: Bool = false
     @State private var originalPrivacy: String = ""
@@ -110,8 +110,6 @@ struct PostEditView: View {
             }
             .task {
                 do {
-                    print(friendRequestListener.acceptedFriendRequests.map {$0.firstName})
-                    print(friendRequestListener.acceptedFriendRequests.count)
                     self.post = try await PostOperationsService().getPost(prayerRequest: post)
                     self.post = post
                     prayerRequestUpdates = try await PostUpdateHelper().getPrayerRequestUpdates(prayerRequest: post, person: person)

--- a/Flock/Views/Model Views/Post View/PostEditView.swift
+++ b/Flock/Views/Model Views/Post View/PostEditView.swift
@@ -22,82 +22,84 @@ struct PostEditView: View {
     @State private var isTruncated: Bool = false
     
     var body: some View {
-        NavigationStack {
-            Form {
-                Section(header: Text("Title")) {
-                    ZStack(alignment: .topLeading) {
-                        if post.postTitle.isEmpty {
-                            Text("Title")
-                                .padding(.top, 8)
-                                .foregroundStyle(Color.gray)
+        NavigationView {
+            VStack {
+                Form {
+                    Section(header: Text("Title")) {
+                        ZStack(alignment: .topLeading) {
+                            if post.postTitle.isEmpty {
+                                Text("Title")
+                                    .padding(.top, 8)
+                                    .foregroundStyle(Color.gray)
+                            }
+                            Text(post.postTitle)
+                                .foregroundStyle(Color.clear)//this is a swift workaround to dynamically expand textEditor.
+                            TextEditor(text: $post.postTitle)
+                                .offset(x: -5, y: -1)
                         }
-                        Text(post.postTitle)
-                            .foregroundStyle(Color.clear)//this is a swift workaround to dynamically expand textEditor.
-                        TextEditor(text: $post.postTitle)
-                            .offset(x: -5, y: -1)
-                    }
-                    .padding(.bottom, -4)
-                    
-                    Picker("Type", selection: $post.postType) {
-                        Text("Default (Post)").tag("Default")
-                        Text("Praise").tag("Praise")
-                        Text("Prayer Request").tag("Prayer Request")
-                    }
-                    if post.postType == "Prayer Request" {
-                        Picker("Status", selection: $post.status) {
-                            Text("Current").tag("Current")
-                            Text("Answered").tag("Answered")
-                            Text("No Longer Needed").tag("No Longer Needed")
+                        .padding(.bottom, -4)
+                        
+                        Picker("Type", selection: $post.postType) {
+                            Text("Default (Post)").tag("Default")
+                            Text("Praise").tag("Praise")
+                            Text("Prayer Request").tag("Prayer Request")
+                        }
+                        if post.postType == "Prayer Request" {
+                            Picker("Status", selection: $post.status) {
+                                Text("Current").tag("Current")
+                                Text("Answered").tag("Answered")
+                                Text("No Longer Needed").tag("No Longer Needed")
+                            }
+                        }
+                        HStack {
+                            Text("Privacy")
+                            Spacer()
+                            PrivacyView(person: person, privacySetting: $post.privacy)
                         }
                     }
-                    HStack {
-                        Text("Privacy")
-                        Spacer()
-                        PrivacyView(person: person, privacySetting: $post.privacy)
-                    }
-                }
-                Section(header: Text("Edit Post")) {
-                    ZStack (alignment: .topLeading) {
-                        if post.postText.isEmpty {
-                            Text("Enter text")
-                                .padding(.top, 8)
-                                .foregroundStyle(Color.gray)
+                    Section(header: Text("Edit Post")) {
+                        ZStack (alignment: .topLeading) {
+                            if post.postText.isEmpty {
+                                Text("Enter text")
+                                    .padding(.top, 8)
+                                    .foregroundStyle(Color.gray)
+                            }
+                            TextEditor(text: $post.postText)
+                                .offset(y: 2)
+                            Text(post.postText)
+                                .hidden() //this is a swift workaround to dynamically expand textEditor.
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .padding(.all, 8)
                         }
-                        TextEditor(text: $post.postText)
-                            .offset(y: 2)
-                        Text(post.postText)
-                            .hidden() //this is a swift workaround to dynamically expand textEditor.
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .padding(.all, 8)
                     }
-                }
-                if prayerRequestUpdates.count > 0 {
-                    ForEach(prayerRequestUpdates) { update in
-                        Section(header: Text("\(update.updateType): \(update.datePosted, style: .date)")) {
-                            VStack(alignment: .leading){
-                                NavigationLink(destination: EditPrayerUpdate(person: person, prayerRequest: post, prayerRequestUpdates: prayerRequestUpdates, update: update)) {
-                                    Text(update.prayerUpdateText)
+                    if prayerRequestUpdates.count > 0 {
+                        ForEach(prayerRequestUpdates) { update in
+                            Section(header: Text("\(update.updateType): \(update.datePosted, style: .date)")) {
+                                VStack(alignment: .leading){
+                                    NavigationLink(destination: EditPrayerUpdate(person: person, prayerRequest: post, prayerRequestUpdates: prayerRequestUpdates, update: update)) {
+                                        Text(update.prayerUpdateText)
+                                    }
                                 }
                             }
                         }
                     }
-                }
-                Section {
-                    Button(action: {
-                        showAddUpdateView.toggle()
-                    }) {Text("Add Update or Testimony")
-                        //                                .font(.system(size: 16))
-                            .foregroundColor(.blue)
-                            .frame(maxWidth: .infinity, alignment: .center)
+                    Section {
+                        Button(action: {
+                            showAddUpdateView.toggle()
+                        }) {Text("Add Update or Testimony")
+                            //                                .font(.system(size: 16))
+                                .foregroundColor(.blue)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                        }
                     }
-                }
-                Section {
-                    Button(action: {
-                        deletePost()
-                    }) {Text("Delete Post")
-                        //                                .font(.system(size: 16))
-                            .foregroundColor(.red)
-                            .frame(maxWidth: .infinity, alignment: .center)
+                    Section {
+                        Button(action: {
+                            deletePost()
+                        }) {Text("Delete Post")
+                            //                                .font(.system(size: 16))
+                                .foregroundColor(.red)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                        }
                     }
                 }
             }
@@ -128,28 +130,27 @@ struct PostEditView: View {
             }) {
                 AddPrayerUpdateView(person: person, prayerRequest: post)
             }
-            .toolbar {
-                ToolbarItemGroup(placement: .topBarTrailing) {
-                    Button(action: {
-                        updatePost(post: post)
-                    }) {
-                        Text("Save")
-                            .offset(x: -4)
-                            .font(.system(size: 14))
-                            .padding([.leading, .trailing], 5)
-                            .bold()
-                            .foregroundStyle(.white)
-                    }
-                    .background(
-                        RoundedRectangle(cornerRadius: 15)
-                            .fill(.blue)
-                    )
-                }
-            }
-//            .toolbarBackground(Color.clear, for: .tabBar)
         }
         .navigationTitle("Edit Post")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                Button(action: {
+                    updatePost(post: post)
+                }) {
+                    Text("Save")
+                        .offset(x: -4)
+                        .font(.system(size: 14))
+                        .padding([.leading, .trailing], 5)
+                        .bold()
+                        .foregroundStyle(.white)
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: 15)
+                        .fill(.blue)
+                )
+            }
+        }
     }
     
     func updatePost(post: Post) {

--- a/Flock/Views/Model Views/Post View/PostEditView.swift
+++ b/Flock/Views/Model Views/Post View/PostEditView.swift
@@ -11,6 +11,7 @@ struct PostEditView: View {
     @Environment(UserProfileHolder.self) var userHolder
     @Environment(FriendRequestListener.self) var friendRequestListener
     @Environment(\.dismiss) var dismiss
+    @Environment(\.colorScheme) var colorScheme
     
     @State var prayerRequestUpdates: [PostUpdate] = []
     var person: Person
@@ -22,83 +23,87 @@ struct PostEditView: View {
     @State private var isTruncated: Bool = false
     
     var body: some View {
-        NavigationView {
-            VStack {
-                Form {
-                    Section(header: Text("Title")) {
-                        ZStack(alignment: .topLeading) {
-                            if post.postTitle.isEmpty {
-                                Text("Title")
-                                    .padding(.top, 8)
-                                    .foregroundStyle(Color.gray)
+            NavigationView {
+                ZStack {
+                    (colorScheme == .dark ? Color.black : Color(.systemGray6))
+                        .ignoresSafeArea()//background
+                    
+                    Form {
+                        Section(header: Text("Title")) {
+                            ZStack(alignment: .topLeading) {
+                                if post.postTitle.isEmpty {
+                                    Text("Title")
+                                        .padding(.top, 8)
+                                        .foregroundStyle(Color.gray)
+                                }
+                                Text(post.postTitle)
+                                    .foregroundStyle(Color.clear)//this is a swift workaround to dynamically expand textEditor.
+                                TextEditor(text: $post.postTitle)
+                                    .offset(x: -5, y: -1)
                             }
-                            Text(post.postTitle)
-                                .foregroundStyle(Color.clear)//this is a swift workaround to dynamically expand textEditor.
-                            TextEditor(text: $post.postTitle)
-                                .offset(x: -5, y: -1)
-                        }
-                        .padding(.bottom, -4)
-                        
-                        Picker("Type", selection: $post.postType) {
-                            Text("Default (Post)").tag("Default")
-                            Text("Praise").tag("Praise")
-                            Text("Prayer Request").tag("Prayer Request")
-                        }
-                        if post.postType == "Prayer Request" {
-                            Picker("Status", selection: $post.status) {
-                                Text("Current").tag("Current")
-                                Text("Answered").tag("Answered")
-                                Text("No Longer Needed").tag("No Longer Needed")
+                            .padding(.bottom, -4)
+                            
+                            Picker("Type", selection: $post.postType) {
+                                Text("Default (Post)").tag("Default")
+                                Text("Praise").tag("Praise")
+                                Text("Prayer Request").tag("Prayer Request")
+                            }
+                            if post.postType == "Prayer Request" {
+                                Picker("Status", selection: $post.status) {
+                                    Text("Current").tag("Current")
+                                    Text("Answered").tag("Answered")
+                                    Text("No Longer Needed").tag("No Longer Needed")
+                                }
+                            }
+                            HStack {
+                                Text("Privacy")
+                                Spacer()
+                                PrivacyView(person: person, privacySetting: $post.privacy)
                             }
                         }
-                        HStack {
-                            Text("Privacy")
-                            Spacer()
-                            PrivacyView(person: person, privacySetting: $post.privacy)
-                        }
-                    }
-                    Section(header: Text("Edit Post")) {
-                        ZStack (alignment: .topLeading) {
-                            if post.postText.isEmpty {
-                                Text("Enter text")
-                                    .padding(.top, 8)
-                                    .foregroundStyle(Color.gray)
+                        Section(header: Text("Edit Post")) {
+                            ZStack (alignment: .topLeading) {
+                                if post.postText.isEmpty {
+                                    Text("Enter text")
+                                        .padding(.top, 8)
+                                        .foregroundStyle(Color.gray)
+                                }
+                                TextEditor(text: $post.postText)
+                                    .offset(y: 2)
+                                Text(post.postText)
+                                    .hidden() //this is a swift workaround to dynamically expand textEditor.
+                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                    .padding(.all, 8)
                             }
-                            TextEditor(text: $post.postText)
-                                .offset(y: 2)
-                            Text(post.postText)
-                                .hidden() //this is a swift workaround to dynamically expand textEditor.
-                                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                .padding(.all, 8)
                         }
-                    }
-                    if prayerRequestUpdates.count > 0 {
-                        ForEach(prayerRequestUpdates) { update in
-                            Section(header: Text("\(update.updateType): \(update.datePosted, style: .date)")) {
-                                VStack(alignment: .leading){
-                                    NavigationLink(destination: EditPrayerUpdate(person: person, prayerRequest: post, prayerRequestUpdates: prayerRequestUpdates, update: update)) {
-                                        Text(update.prayerUpdateText)
+                        if prayerRequestUpdates.count > 0 {
+                            ForEach(prayerRequestUpdates) { update in
+                                Section(header: Text("\(update.updateType): \(update.datePosted, style: .date)")) {
+                                    VStack(alignment: .leading){
+                                        NavigationLink(destination: EditPrayerUpdate(person: person, prayerRequest: post, prayerRequestUpdates: prayerRequestUpdates, update: update)) {
+                                            Text(update.prayerUpdateText)
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                    Section {
-                        Button(action: {
-                            showAddUpdateView.toggle()
-                        }) {Text("Add Update or Testimony")
-                            //                                .font(.system(size: 16))
-                                .foregroundColor(.blue)
-                                .frame(maxWidth: .infinity, alignment: .center)
+                        Section {
+                            Button(action: {
+                                showAddUpdateView.toggle()
+                            }) {Text("Add Update or Testimony")
+                                //                                .font(.system(size: 16))
+                                    .foregroundColor(.blue)
+                                    .frame(maxWidth: .infinity, alignment: .center)
+                            }
                         }
-                    }
-                    Section {
-                        Button(action: {
-                            deletePost()
-                        }) {Text("Delete Post")
-                            //                                .font(.system(size: 16))
-                                .foregroundColor(.red)
-                                .frame(maxWidth: .infinity, alignment: .center)
+                        Section {
+                            Button(action: {
+                                deletePost()
+                            }) {Text("Delete Post")
+                                //                                .font(.system(size: 16))
+                                    .foregroundColor(.red)
+                                    .frame(maxWidth: .infinity, alignment: .center)
+                            }
                         }
                     }
                 }
@@ -130,27 +135,26 @@ struct PostEditView: View {
             }) {
                 AddPrayerUpdateView(person: person, prayerRequest: post)
             }
-        }
-        .navigationTitle("Edit Post")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                Button(action: {
-                    updatePost(post: post)
-                }) {
-                    Text("Save")
-                        .offset(x: -4)
-                        .font(.system(size: 14))
-                        .padding([.leading, .trailing], 5)
-                        .bold()
-                        .foregroundStyle(.white)
+            .navigationTitle("Edit Post")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    Button(action: {
+                        updatePost(post: post)
+                    }) {
+                        Text("Save")
+                            .offset(x: -4)
+                            .font(.system(size: 14))
+                            .padding([.leading, .trailing], 5)
+                            .bold()
+                            .foregroundStyle(.white)
+                    }
+                    .background(
+                        RoundedRectangle(cornerRadius: 15)
+                            .fill(.blue)
+                    )
                 }
-                .background(
-                    RoundedRectangle(cornerRadius: 15)
-                        .fill(.blue)
-                )
             }
-        }
     }
     
     func updatePost(post: Post) {

--- a/Flock/Views/Model Views/Post View/PostFullView.swift
+++ b/Flock/Views/Model Views/Post View/PostFullView.swift
@@ -40,7 +40,7 @@ struct PostFullView: View {
                     
                     VStack() {
                         HStack {
-                            Text(post.firstName + " " + post.lastName).font(.system(size: 18)).bold()
+                            Text(post.firstName.capitalized + " " + post.lastName.capitalized).font(.system(size: 18)).bold()
                             Spacer()
                         }
                         HStack() {

--- a/Flock/Views/Model Views/Post View/SubmitPostForm.swift
+++ b/Flock/Views/Model Views/Post View/SubmitPostForm.swift
@@ -29,7 +29,7 @@ struct SubmitPostForm: View {
     var friendService = FriendService()
     
     var body: some View {
-        NavigationView{
+        NavigationStack{
             ZStack {
                 (colorScheme == .light ? Color(.systemGray6) : .clear)
                     .ignoresSafeArea()
@@ -195,38 +195,22 @@ struct SubmitPostForm: View {
         print("Draft cleared")
     }
     
-//    func refreshFriends() {
-//        Task {
-//            do {
-//                userHolder.friendsList = try await friendService.getFriendsList(userID: userHolder.person.userID).0
-//                self.userHolder.friendsList = userHolder.friendsList
-//            } catch {
-//                print(error)
-//            }
-//        }
-//    }
-    
     @ViewBuilder
     func friendsList() -> some View {
-//        let friendsList = userHolder.friendsList.map({
-//            $0.firstName + " " + $0.lastName
-//        }).joined(separator: ", ")
-        ScrollView {
-            VStack (alignment: .leading) {
-                HStack {
-                    Text("Who can see this post?")
-                         .multilineTextAlignment(.leading)
-                         .padding(.bottom, 1)
-                    NavigationLink(destination: FriendsPageView()) {
-                        Text("See Friends")
-                            .font(.system(size: 12))
-                            .italic()
-                    }
-                    Spacer()
+        VStack (alignment: .leading) {
+            HStack {
+                Text("Who can see this post?")
+                    .multilineTextAlignment(.leading)
+                    .padding(.bottom, 1)
+                NavigationLink(destination: FriendsPageView()) {
+                    Text("See Friends")
+                        .font(.system(size: 12))
+                        .italic()
                 }
-                .font(.system(size: 12))
-                .padding(.bottom, 10)
+                Spacer()
             }
+            .font(.system(size: 12))
+            .padding(.bottom, 10)
         }
     }
 }

--- a/Flock/Views/Model Views/Post View/SubmitPostForm.swift
+++ b/Flock/Views/Model Views/Post View/SubmitPostForm.swift
@@ -15,7 +15,7 @@ struct SubmitPostForm: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) var dismiss
     
-    var person: Person
+    @State var person: Person
     @State private var datePosted = Date()
     @State private var status: String = "Current"
     @State private var postText: String = ""
@@ -77,11 +77,11 @@ struct SubmitPostForm: View {
                             Text("Privacy")
                             Spacer()
                             PrivacyView(person: person, privacySetting: $privacy)
-                                .task {
-                                    if person.isPrivateFriend {
-                                        privacy = "private"
-                                    }
-                                }
+//                                .task {
+//                                    if person.isPrivateFriend {
+//                                        privacy = "private"
+//                                    }
+//                                }
                                 .onChange(of: privacy, {
                                     if privacy == "public" {
                                         isPresentingFriends = true
@@ -226,19 +226,6 @@ struct SubmitPostForm: View {
                 }
                 .font(.system(size: 12))
                 .padding(.bottom, 10)
-//                
-//                HStack {
-//                    Text("Don't see a friend on here?")
-//                    Button(action: {
-//                        self.refreshFriends()
-//                    }, label: {
-//                        Text("Refresh")
-//                            .font(.system(size: 12))
-//                            .italic()
-//                    })
-//                    Spacer()
-//                }
-//                .font(.system(size: 12))
             }
         }
     }

--- a/Flock/Views/Model Views/Post View/SubmitPostForm.swift
+++ b/Flock/Views/Model Views/Post View/SubmitPostForm.swift
@@ -12,6 +12,7 @@ import FirebaseFirestore
 struct SubmitPostForm: View {
     @Environment(UserProfileHolder.self) var userHolder
     @Environment(FriendRequestListener.self) var friendRequestListener
+    @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) var dismiss
     
     var person: Person
@@ -29,7 +30,10 @@ struct SubmitPostForm: View {
     
     var body: some View {
         NavigationView{
-            VStack {
+            ZStack {
+                (colorScheme == .light ? Color(.systemGray6) : .clear)
+                    .ignoresSafeArea()
+                
                 Form {
                     Section(/*header: Text("Share a Prayer Request")*/) {
                         ZStack(alignment: .topLeading) {

--- a/Flock/Views/Model Views/Post View/SubmitPostForm.swift
+++ b/Flock/Views/Model Views/Post View/SubmitPostForm.swift
@@ -74,7 +74,7 @@ struct SubmitPostForm: View {
                             Spacer()
                             PrivacyView(person: person, privacySetting: $privacy)
                                 .task {
-                                    if person.username == "" && person.userID == userHolder.person.userID {
+                                    if person.isPrivateFriend {
                                         privacy = "private"
                                     }
                                 }

--- a/Flock/Views/Model Views/PostRow.swift
+++ b/Flock/Views/Model Views/PostRow.swift
@@ -79,7 +79,7 @@ struct PostRow: View {
                         .padding(.bottom, 2)
                         HStack {
                             if post.postType == "Prayer Request" {
-                                Text("Prayer Status: ").font(.system(size: 12)) + Text(post.status.capitalized).font(.system(size: 12)).bold()
+                                Text("Prayer Request: ").font(.system(size: 12)) + Text(post.status.capitalized).font(.system(size: 12)).bold()
                             } else if post.postType == "Praise" {
                                 Text("Praise 🙌").font(.system(size: 12))
                             } else {

--- a/Flock/Views/Model Views/PostRow.swift
+++ b/Flock/Views/Model Views/PostRow.swift
@@ -13,6 +13,7 @@ struct PostRow: View {
     @State var viewModel: FeedViewModel
     @Environment(\.colorScheme) private var scheme
     @Binding var post: Post
+    @State var person: Person = Person()
     @Environment(UserProfileHolder.self) var userHolder
     
     // For Update
@@ -56,7 +57,7 @@ struct PostRow: View {
                             Privacy(rawValue: post.privacy)?.systemImage
                             Menu {
                                 if post.userID == userHolder.person.userID {
-                                    NavigationLink(destination: PostEditView(person: userHolder.person, post: post)){
+                                    NavigationLink(destination: PostEditView(person: person, post: post)){
                                         Label("Edit Post", systemImage: "pencil")
                                     } // can only edit if you are the owner of the post.
                                 }
@@ -78,7 +79,7 @@ struct PostRow: View {
                         .padding(.bottom, 2)
                         HStack {
                             if post.postType == "Prayer Request" {
-                                Text("Prayer Status: ").font(.system(size: 12)) + Text(post.status.capitalized)                        .font(.system(size: 12)).bold()
+                                Text("Prayer Status: ").font(.system(size: 12)) + Text(post.status.capitalized).font(.system(size: 12)).bold()
                             } else if post.postType == "Praise" {
                                 Text("Praise 🙌").font(.system(size: 12))
                             } else {

--- a/Flock/Views/Model Views/PostRow.swift
+++ b/Flock/Views/Model Views/PostRow.swift
@@ -48,7 +48,7 @@ struct PostRow: View {
                     
                     VStack(alignment: .leading) {
                         HStack() {
-                            Text(post.firstName + " " + post.lastName).font(.system(size: 18)).bold()
+                            Text(post.firstName.capitalized + " " + post.lastName.capitalized).font(.system(size: 18)).bold()
                             Spacer()
                             if post.isPinned == true {
                                 Image(systemName: "pin.fill")

--- a/Flock/Views/Sign-In View/CreateProfileView.swift
+++ b/Flock/Views/Sign-In View/CreateProfileView.swift
@@ -160,8 +160,8 @@ struct CreateProfileView: View {
                                     ["email": email,
                                      "userID": userID ?? "",
                                      "username": username.lowercased(),
-                                     "firstName": firstName.capitalized,
-                                     "lastName": lastName.capitalized]
+                                     "firstName": firstName.lowercased(),
+                                     "lastName": lastName.lowercased()]
                                 )
                                 
                                 let refUsernames = db.collection("usernames").document("\(username)")

--- a/Flock/Views/Sign-In View/CreateProfileView.swift
+++ b/Flock/Views/Sign-In View/CreateProfileView.swift
@@ -192,7 +192,7 @@ struct CreateProfileView: View {
         let userID = Auth.auth().currentUser?.uid ?? ""
         
         do {
-            userHolder.person = try await UserService().getUserInfo(userID: userID)
+            userHolder.person = try await UserService().getBasicUserInfo(userID: userID)
             // This sets firstName, lastName, username, and userID for UserHolder
             let postList = try await calendarService.getPrayerCalendarList(userID: userID)
             userHolder.prayStartDate = postList.0 // set Start Date

--- a/Flock/Views/Sign-In View/SignInView.swift
+++ b/Flock/Views/Sign-In View/SignInView.swift
@@ -216,7 +216,7 @@ struct SignInView: View {
             userHolder.viewState = .loading
             defer { userHolder.viewState = .finished }
             
-            userHolder.person = try await UserService().getUserInfo(userID: userID)
+            userHolder.person = try await UserService().getBasicUserInfo(userID: userID)
             // This sets firstName, lastName, username, and userID for UserHolder
             
 //            try await setFriendsList(userID: userHolder.person.userID) // setFriendsList for userHolder

--- a/Flock/Views/Sign-In View/SignInView.swift
+++ b/Flock/Views/Sign-In View/SignInView.swift
@@ -237,16 +237,6 @@ struct SignInView: View {
             userHolder.isLoggedIn = .notAuthenticated
         }
     }
-//    
-//    func setFriendsList(userID: String) async throws {
-//        do {
-//            let friends = try await friendService.getFriendsList(userID: userHolder.person.userID) // run to refresh friends list on command
-//            userHolder.friendsList = friends.0
-////            userHolder.pendingFriendsList = friends.1
-//        } catch {
-//            print(error)
-//        }
-//    }
 }
 
 


### PR DESCRIPTION
This feature replaces the tool 'prayer name input list' from PrayerCalendar by providing UI through the Friends Page to add a private friend. Adding a private friend creates a profile within the user's account that only they have access to. This allows them to track prayer requests that they have for a specific friend.

Add Friend Form
- Enabled option to add a private friend via first name and last name

Friend Page
- Added 'private friends' section

Submit Post Form and Edit Post Form
- Forces all posts for private friends to be limited to 'private' so that it does not share to other people's feeds
- Fixed some UI issues causing coloring of background to be off.

Profile View
- Added 'tags' to friends, including a 'private' friend option

Other
- Minor backend refactoring and fixes
- REMOVED Prayer Calendar tab. To be considered again in the future.