### PR TITLE
Feature/build-prayer-topic-service-dtos-and-update-entitytypes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
   "cSpell.words": [
     "Firestore",
-    "PRAYERPOINTS"
+    "PRAYERPOINTS",
+    "PRAYERTOPICS"
   ],
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"

--- a/FlockRN/app/(tabs)/(prayers)/(createPrayer)/prayerMetadata.tsx
+++ b/FlockRN/app/(tabs)/(prayers)/(createPrayer)/prayerMetadata.tsx
@@ -25,7 +25,7 @@ import useUserContext from '@/hooks/useUserContext';
 import OpenAiService from '@/services/ai/openAIService';
 import PrayerContent from '@/components/Prayer/PrayerViews/PrayerContent';
 import { usePrayerCollection } from '@/context/PrayerCollectionContext';
-import { PrayerOrPrayerPointType } from '@/types/PrayerSubtypes';
+import { PrayerEntityType } from '@/types/PrayerSubtypes';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { HeaderButton } from '@/components/ui/HeaderButton';
 import { EditMode } from '@/types/ComponentProps';
@@ -66,6 +66,7 @@ export default function PrayerMetadataScreen() {
     authorId: '',
     privacy: 'private',
     prayerPoints: [],
+    entityType: PrayerEntityType.Prayer,
   });
   const colorScheme = useThemeColor({}, 'backgroundSecondary');
 
@@ -364,7 +365,7 @@ export default function PrayerMetadataScreen() {
       <PrayerContent
         editMode={isEditMode ? EditMode.EDIT : EditMode.CREATE}
         backgroundColor={colorScheme}
-        prayerOrPrayerPoint={PrayerOrPrayerPointType.Prayer}
+        prayerOrPrayerPoint={PrayerEntityType.Prayer}
         prayer={prayer}
         onChange={(updatedPrayer) => {
           handlePrayerUpdate(updatedPrayer as Prayer);

--- a/FlockRN/app/(tabs)/(prayers)/(createPrayerPoint)/createPrayerPoint.tsx
+++ b/FlockRN/app/(tabs)/(prayers)/(createPrayerPoint)/createPrayerPoint.tsx
@@ -21,7 +21,7 @@ import PrayerContent from '@/components/Prayer/PrayerViews/PrayerContent';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { ThemedKeyboardAvoidingView } from '@/components/ThemedKeyboardAvoidingView';
 import { HeaderButton } from '@/components/ui/HeaderButton';
-import { PrayerOrPrayerPointType } from '@/types/PrayerSubtypes';
+import { PrayerEntityType } from '@/types/PrayerSubtypes';
 import { usePrayerCollection } from '@/context/PrayerCollectionContext';
 import PrayerPointLinking from '@/components/Prayer/PrayerViews/PrayerPointLinking';
 import OpenAiService from '@/services/ai/openAIService';
@@ -48,7 +48,6 @@ export default function PrayerPointMetadataScreen() {
   const [similarPrayerPoints, setSimilarPrayerPoints] = useState<PrayerPoint[]>(
     [],
   );
-
   const [privacy, setPrivacy] = useState<'public' | 'private'>('private');
   const [isLoading, setIsLoading] = useState(false);
   const colorScheme = useThemeColor({}, 'backgroundSecondary');
@@ -248,7 +247,7 @@ export default function PrayerPointMetadataScreen() {
     }
   };
 
-  useEffect(() => {
+  useMemo(() => {
     setupEditMode();
   }, [setupEditMode]);
 
@@ -271,7 +270,7 @@ export default function PrayerPointMetadataScreen() {
         <View style={styles.upperContainer}>
           <PrayerContent
             editMode={isEditMode ? EditMode.EDIT : EditMode.CREATE}
-            prayerOrPrayerPoint={PrayerOrPrayerPointType.PrayerPoint}
+            prayerOrPrayerPoint={PrayerEntityType.PrayerPoint}
             backgroundColor={colorScheme}
             onChange={(updatedPrayerPointData) => {
               if ('type' in updatedPrayerPointData) {

--- a/FlockRN/app/(tabs)/(prayers)/(createPrayerPoint)/createPrayerPoint.tsx
+++ b/FlockRN/app/(tabs)/(prayers)/(createPrayerPoint)/createPrayerPoint.tsx
@@ -129,7 +129,7 @@ export default function PrayerPointMetadataScreen() {
     }
 
     try {
-      const similarPrayers = await prayerService.findRelatedPrayerPoints(
+      const similarPrayers = await prayerService.findRelatedPrayers(
         embedding,
         user.uid,
       );
@@ -184,7 +184,10 @@ export default function PrayerPointMetadataScreen() {
           status: updatedPrayerPoint.status,
         };
 
-        await prayerService.editPrayerPoint(updatedPrayerPoint.id, updateData);
+        await prayerService.updatePrayerPoint(
+          updatedPrayerPoint.id,
+          updateData,
+        );
 
         // Update the prayer point in the collection context
         const updatedPrayerPointFinal = {

--- a/FlockRN/app/(tabs)/(prayers)/prayerPointView.tsx
+++ b/FlockRN/app/(tabs)/(prayers)/prayerPointView.tsx
@@ -20,7 +20,7 @@ import { HeaderButton } from '@/components/ui/HeaderButton';
 import { usePrayerCollection } from '@/context/PrayerCollectionContext';
 import { Colors } from '@/constants/Colors';
 import { auth } from '@/firebase/firebaseConfig';
-import { PrayerOrPrayerPointType } from '@/types/PrayerSubtypes';
+import { PrayerEntityType } from '@/types/PrayerSubtypes';
 import { EditMode } from '@/types/ComponentProps';
 
 const PrayerPointView = () => {
@@ -139,7 +139,7 @@ const PrayerPointView = () => {
       prayerPoint.createdAt instanceof Date
         ? prayerPoint.createdAt
         : typeof prayerPoint.createdAt === 'object' &&
-            'seconds' in prayerPoint.createdAt
+          'seconds' in prayerPoint.createdAt
           ? new Date(prayerPoint.createdAt.seconds * 1000)
           : new Date(prayerPoint.createdAt);
 
@@ -190,7 +190,7 @@ const PrayerPointView = () => {
             <PrayerContent
               editMode={EditMode.VIEW}
               prayer={prayerPoint}
-              prayerOrPrayerPoint={PrayerOrPrayerPointType.PrayerPoint}
+              prayerOrPrayerPoint={PrayerEntityType.PrayerPoint}
               backgroundColor={backgroundColor}
             />
 

--- a/FlockRN/app/(tabs)/(prayers)/prayerPointView.tsx
+++ b/FlockRN/app/(tabs)/(prayers)/prayerPointView.tsx
@@ -139,7 +139,7 @@ const PrayerPointView = () => {
       prayerPoint.createdAt instanceof Date
         ? prayerPoint.createdAt
         : typeof prayerPoint.createdAt === 'object' &&
-          'seconds' in prayerPoint.createdAt
+            'seconds' in prayerPoint.createdAt
           ? new Date(prayerPoint.createdAt.seconds * 1000)
           : new Date(prayerPoint.createdAt);
 

--- a/FlockRN/app/(tabs)/(prayers)/prayerView.tsx
+++ b/FlockRN/app/(tabs)/(prayers)/prayerView.tsx
@@ -13,7 +13,7 @@ import { HeaderButton } from '@/components/ui/HeaderButton';
 import { usePrayerCollection } from '@/context/PrayerCollectionContext';
 import { PrayerPoint } from '@/types/firebase';
 import { forEach } from 'lodash';
-import { PrayerOrPrayerPointType } from '@/types/PrayerSubtypes';
+import { PrayerEntityType } from '@/types/PrayerSubtypes';
 import { EditMode } from '@/types/ComponentProps';
 
 const PrayerView = () => {
@@ -123,7 +123,7 @@ const PrayerView = () => {
             <PrayerContent
               editMode={EditMode.VIEW}
               prayer={prayer}
-              prayerOrPrayerPoint={PrayerOrPrayerPointType.Prayer}
+              prayerOrPrayerPoint={PrayerEntityType.Prayer}
               backgroundColor={colorScheme}
             />
             {prayerPoints && (

--- a/FlockRN/components/Prayer/PrayerViews/PrayerCard.tsx
+++ b/FlockRN/components/Prayer/PrayerViews/PrayerCard.tsx
@@ -1,5 +1,5 @@
 import { ThemedText } from '@/components/ThemedText';
-import { Prayer, PrayerPoint } from '@/types/firebase';
+import { Prayer, PrayerPoint, PrayerTopic } from '@/types/firebase';
 import {
   TouchableOpacity,
   StyleSheet,
@@ -11,9 +11,10 @@ import { router } from 'expo-router';
 import { EmojiIconBackground } from '@/components/ui/EmojiIconBackground';
 import { prayerTagDisplayNames } from '@/types/Tag';
 import { useMemo } from 'react';
+import { getEntityType } from '@/types/typeGuards';
 
 export interface PrayerCardProps {
-  prayer: Prayer | PrayerPoint;
+  prayer: Prayer | PrayerPoint | PrayerTopic;
 }
 
 export default function PrayerCard({ prayer }: PrayerCardProps): JSX.Element {
@@ -36,9 +37,16 @@ export default function PrayerCard({ prayer }: PrayerCardProps): JSX.Element {
     });
   })();
 
-  const isPrayerPoint = useMemo(() => {
-    return 'type' in prayer;
+  const entityType = useMemo(() => {
+    return getEntityType(prayer);
   }, [prayer]);
+
+  console.log('entityType', entityType);
+
+  // Use the entityType to create the boolean checks
+  const isPrayerPoint = entityType === 'prayerPoint';
+  const isPrayer = entityType === 'prayer';
+  const isPrayerTopic = entityType === 'prayerTopic';
 
   return (
     <TouchableOpacity

--- a/FlockRN/components/Prayer/PrayerViews/PrayerCard.tsx
+++ b/FlockRN/components/Prayer/PrayerViews/PrayerCard.tsx
@@ -45,8 +45,6 @@ export default function PrayerCard({ prayer }: PrayerCardProps): JSX.Element {
 
   // Use the entityType to create the boolean checks
   const isPrayerPoint = entityType === 'prayerPoint';
-  const isPrayer = entityType === 'prayer';
-  const isPrayerTopic = entityType === 'prayerTopic';
 
   return (
     <TouchableOpacity

--- a/FlockRN/components/Prayer/PrayerViews/PrayerCard.tsx
+++ b/FlockRN/components/Prayer/PrayerViews/PrayerCard.tsx
@@ -41,8 +41,6 @@ export default function PrayerCard({ prayer }: PrayerCardProps): JSX.Element {
     return getEntityType(prayer);
   }, [prayer]);
 
-  console.log('entityType', entityType);
-
   // Use the entityType to create the boolean checks
   const isPrayerPoint = entityType === 'prayerPoint';
 

--- a/FlockRN/components/Prayer/PrayerViews/PrayerContent.tsx
+++ b/FlockRN/components/Prayer/PrayerViews/PrayerContent.tsx
@@ -66,7 +66,7 @@ export function PrayerContent({
   return (
     <View style={[styles.container, { backgroundColor: backgroundColor }]}>
       {(editMode === EditMode.EDIT || editMode === EditMode.CREATE) &&
-        prayerOrPrayerPoint === 'prayerPoint' ? (
+      prayerOrPrayerPoint === 'prayerPoint' ? (
         <TextInput
           style={[styles.titleText, styles.input]}
           value={prayer?.title}

--- a/FlockRN/components/Prayer/PrayerViews/PrayerContent.tsx
+++ b/FlockRN/components/Prayer/PrayerViews/PrayerContent.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, TextInput, View } from 'react-native';
 import { ThemedText } from '@/components/ThemedText';
 import TagsSection from '@/components/Prayer/PrayerViews/TagsSection';
-import { PrayerOrPrayerPointType, PrayerType } from '@/types/PrayerSubtypes';
+import { PrayerEntityType, PrayerType } from '@/types/PrayerSubtypes';
 import { Prayer, PrayerPoint } from '@/types/firebase';
 import { EditMode } from '@/types/ComponentProps';
 
@@ -14,7 +14,7 @@ export function PrayerContent({
 }: {
   editMode: EditMode;
   backgroundColor?: string;
-  prayerOrPrayerPoint: PrayerOrPrayerPointType;
+  prayerOrPrayerPoint: PrayerEntityType;
   prayer?: Prayer | PrayerPoint; // only required for edit and view modes
   onChange?: (updatedPrayer: PrayerPoint | Prayer) => void;
 }): JSX.Element {
@@ -66,7 +66,7 @@ export function PrayerContent({
   return (
     <View style={[styles.container, { backgroundColor: backgroundColor }]}>
       {(editMode === EditMode.EDIT || editMode === EditMode.CREATE) &&
-      prayerOrPrayerPoint === 'prayerPoint' ? (
+        prayerOrPrayerPoint === 'prayerPoint' ? (
         <TextInput
           style={[styles.titleText, styles.input]}
           value={prayer?.title}

--- a/FlockRN/schema/firebaseCollections.ts
+++ b/FlockRN/schema/firebaseCollections.ts
@@ -3,6 +3,7 @@ export enum FirestoreCollections {
   PRAYERS = 'prayers',
   FEED = 'feeds',
   PRAYERPOINTS = 'prayerPoints',
+  PRAYERTOPICS = 'prayerTopics',
 }
 
 export enum FriendRequestFields {

--- a/FlockRN/services/prayer/prayerService.ts
+++ b/FlockRN/services/prayer/prayerService.ts
@@ -35,6 +35,7 @@ import { FirestoreCollections } from '@/schema/firebaseCollections';
 import { User } from 'firebase/auth';
 import { getFunctions, httpsCallable } from 'firebase/functions';
 import { getApp } from 'firebase/app';
+import { PrayerEntityType } from '@/types/PrayerSubtypes';
 
 class PrayerService {
   private prayersCollection = collection(db, FirestoreCollections.PRAYERS);
@@ -57,6 +58,7 @@ class PrayerService {
         ...data,
         createdAt: now,
         updatedAt: now,
+        entityType: PrayerEntityType.Prayer,
       });
 
       // After the document is created, update it with the generated ID
@@ -204,6 +206,7 @@ class PrayerService {
           ...point, // Use the actual prayer point data
           createdAt: now,
           updatedAt: now,
+          entityType: PrayerEntityType.PrayerPoint,
         });
 
         // After the document is created, update it with the generated ID
@@ -230,6 +233,7 @@ class PrayerService {
         ...data,
         createdAt: now,
         updatedAt: now,
+        entityType: PrayerEntityType.PrayerPoint,
       });
 
       // After the document is created, update it with the generated ID
@@ -533,6 +537,7 @@ class PrayerService {
         ...data,
         createdAt: now,
         updatedAt: now,
+        entityType: PrayerEntityType.PrayerTopic,
       });
 
       // After the document is created, update it with the generated ID
@@ -574,6 +579,7 @@ class PrayerService {
       createdAt: data.createdAt as Date,
       updatedAt: data.updatedAt as Date,
       prayerPoints: data.prayerPoints,
+      entityType: data.entityType as PrayerEntityType,
     };
   }
 
@@ -598,6 +604,7 @@ class PrayerService {
       recipientName: data.recipientName,
       isOrigin: data.isOrigin,
       embedding: data.embedding,
+      entityType: data.entityType as PrayerEntityType,
     };
   }
 
@@ -620,6 +627,7 @@ class PrayerService {
       journey: data.journey,
       contextAsStrings: data.contextAsStrings,
       contextAsEmbeddings: data.contextAsEmbeddings,
+      entityType: data.entityType as PrayerEntityType,
     };
   }
 }

--- a/FlockRN/services/prayer/prayerService.ts
+++ b/FlockRN/services/prayer/prayerService.ts
@@ -27,15 +27,14 @@ import {
   UpdatePrayerDTO,
   CreatePrayerPointDTO,
   UpdatePrayerPointDTO,
-  PrayerType,
   PrayerTopic,
   CreatePrayerTopicDTO,
 } from '@/types/firebase';
+import { PrayerType, PrayerEntityType } from '@/types/PrayerSubtypes';
 import { FirestoreCollections } from '@/schema/firebaseCollections';
 import { User } from 'firebase/auth';
 import { getFunctions, httpsCallable } from 'firebase/functions';
 import { getApp } from 'firebase/app';
-import { PrayerEntityType } from '@/types/PrayerSubtypes';
 
 class PrayerService {
   private prayersCollection = collection(db, FirestoreCollections.PRAYERS);

--- a/FlockRN/types/PrayerSubtypes.ts
+++ b/FlockRN/types/PrayerSubtypes.ts
@@ -1,8 +1,9 @@
 import { allTags } from './Tag';
 
-export enum PrayerOrPrayerPointType {
+export enum PrayerEntityType {
   Prayer = 'prayer',
   PrayerPoint = 'prayerPoint',
+  PrayerTopic = 'prayerTopic',
 }
 
 export type PrayerTag = (typeof allTags)[number];

--- a/FlockRN/types/firebase.ts
+++ b/FlockRN/types/firebase.ts
@@ -69,6 +69,7 @@ export interface PrayerPoint {
   tags?: PrayerType[];
   status?: Status;
   privacy?: Privacy;
+  prayerUpdates?: [];
   recipientName?: string;
   recipientId?: string;
   embedding?: number[];

--- a/FlockRN/types/firebase.ts
+++ b/FlockRN/types/firebase.ts
@@ -124,6 +124,12 @@ export type UpdatePrayerPointDTO = Partial<
   Omit<PrayerPoint, 'id' | 'createdAt'>
 >;
 
+export type CreatePrayerTopicDTO = Omit<PrayerTopic, 'id' | 'updatedAt'>;
+
+export type UpdatePrayerTopicDTO = Partial<
+  Omit<PrayerTopic, 'id' | 'createdAt'>
+>;
+
 // may want to refactor this in the future if document becomes too large.
 export type PrayerPointInPrayerTopicDTO = Pick<
   PrayerPoint,

--- a/FlockRN/types/firebase.ts
+++ b/FlockRN/types/firebase.ts
@@ -3,6 +3,8 @@
 // set all types for Firebase
 import { PrayerTag, PrayerType, Privacy, Status } from './PrayerSubtypes';
 
+// ===== UserProfiles =====
+
 export interface UserProfile {
   email: string;
   username: string;
@@ -22,6 +24,8 @@ export interface UserProfileResponse extends UserProfile {
   id: string;
 }
 
+// ===== Friends =====
+
 export interface FriendRequest {
   userId: string;
   username: string;
@@ -38,6 +42,7 @@ export interface Group {
   createdAt: Date;
 }
 
+// ===== Prayer Types =====
 export interface Prayer {
   id: string;
   content: string;
@@ -66,19 +71,28 @@ export interface PrayerPoint {
   privacy?: Privacy;
   recipientName?: string;
   recipientId?: string;
-  prayerUpdates?: PrayerPointUpdate[];
   embedding?: number[];
   isOrigin: boolean;
 }
 
-export interface PrayerPointUpdate {
+export interface PrayerTopic {
   id: string;
-  authorId: string;
-  authorName: string;
-  content: string;
+  title: string;
   createdAt: Date;
+  updatedAt: Date;
+  authorName: string;
+  authorId: string;
+  prayerTypes?: PrayerType[];
+  status?: Status;
+  privacy?: Privacy;
+  recipientName?: string;
+  recipientId?: string;
+  journey: PrayerPointInPrayerTopicDTO[];
+  contextAsStrings: string;
+  contextAsEmbeddings: number[];
 }
 
+// ===== Other Types =====
 export interface Category {
   id: string;
   name: string;
@@ -91,7 +105,7 @@ export interface FeedPrayer {
   addedAt: Date;
 }
 
-// DTOs for creating/updating
+// ==== DTOs for creating/updating ====
 export type CreatePrayerDTO = Omit<
   Prayer,
   'id' | 'createdAt' | 'updatedAt' | 'prayerPoints'
@@ -110,6 +124,18 @@ export type UpdatePrayerPointDTO = Partial<
   Omit<PrayerPoint, 'id' | 'createdAt'>
 >;
 
+// may want to refactor this in the future if document becomes too large.
+export type PrayerPointInPrayerTopicDTO = Pick<
+  PrayerPoint,
+  | 'id'
+  | 'type'
+  | 'title'
+  | 'content'
+  | 'createdAt'
+  | 'authorName'
+  | 'recipientName'
+>;
+
 export interface ServiceResponse {
   success: boolean;
   message?: string;
@@ -117,7 +143,7 @@ export interface ServiceResponse {
   errorMessage?: string;
 }
 
-// AI Analysis Result Type
+// ==== AI Analysis Result Type ====
 export interface PrayerAnalysisResult {
   title: string;
   cleanedTranscription?: string;

--- a/FlockRN/types/firebase.ts
+++ b/FlockRN/types/firebase.ts
@@ -87,8 +87,10 @@ export interface PrayerPoint {
 export interface PrayerTopic {
   id: string;
   title: string;
+  content: string; // summary of the prayer topic
   createdAt: Date;
   updatedAt: Date;
+  endDate?: Date;
   authorName: string;
   authorId: string;
   prayerTypes?: PrayerType[];
@@ -122,7 +124,7 @@ export type CreatePrayerDTO = Omit<
 >;
 
 export type UpdatePrayerDTO = Partial<
-  Omit<Prayer, 'id' | 'createdAt' | 'updatedAt'> | 'entityType'
+  Omit<Prayer, 'id' | 'createdAt' | 'updatedAt' | 'entityType'>
 >;
 
 export type CreatePrayerPointDTO = Omit<
@@ -131,7 +133,7 @@ export type CreatePrayerPointDTO = Omit<
 >;
 
 export type UpdatePrayerPointDTO = Partial<
-  Omit<PrayerPoint, 'id' | 'createdAt'> | 'entityType'
+  Omit<PrayerPoint, 'id' | 'createdAt' | 'entityType'>
 >;
 
 export type CreatePrayerTopicDTO = Omit<

--- a/FlockRN/types/firebase.ts
+++ b/FlockRN/types/firebase.ts
@@ -1,7 +1,13 @@
 // ramon jiang
 // 1/29/25
 // set all types for Firebase
-import { PrayerTag, PrayerType, Privacy, Status } from './PrayerSubtypes';
+import {
+  PrayerEntityType,
+  PrayerTag,
+  PrayerType,
+  Privacy,
+  Status,
+} from './PrayerSubtypes';
 
 // ===== UserProfiles =====
 
@@ -54,6 +60,7 @@ export interface Prayer {
   privacy: Privacy;
   prayerPoints: string[];
   tags?: PrayerType[];
+  entityType: PrayerEntityType;
 }
 
 export interface PrayerPoint {
@@ -74,6 +81,7 @@ export interface PrayerPoint {
   recipientId?: string;
   embedding?: number[];
   isOrigin: boolean;
+  entityType: PrayerEntityType;
 }
 
 export interface PrayerTopic {
@@ -91,6 +99,7 @@ export interface PrayerTopic {
   journey: PrayerPointInPrayerTopicDTO[];
   contextAsStrings: string;
   contextAsEmbeddings: number[];
+  entityType: PrayerEntityType;
 }
 
 // ===== Other Types =====
@@ -109,26 +118,29 @@ export interface FeedPrayer {
 // ==== DTOs for creating/updating ====
 export type CreatePrayerDTO = Omit<
   Prayer,
-  'id' | 'createdAt' | 'updatedAt' | 'prayerPoints'
+  'id' | 'createdAt' | 'updatedAt' | 'prayerPoints' | 'entityType'
 >;
 
 export type UpdatePrayerDTO = Partial<
-  Omit<Prayer, 'id' | 'createdAt' | 'updatedAt'>
+  Omit<Prayer, 'id' | 'createdAt' | 'updatedAt'> | 'entityType'
 >;
 
 export type CreatePrayerPointDTO = Omit<
   PrayerPoint,
-  'id' | 'prayerId' | 'updatedAt'
+  'id' | 'prayerId' | 'updatedAt' | 'entityType'
 >;
 
 export type UpdatePrayerPointDTO = Partial<
-  Omit<PrayerPoint, 'id' | 'createdAt'>
+  Omit<PrayerPoint, 'id' | 'createdAt'> | 'entityType'
 >;
 
-export type CreatePrayerTopicDTO = Omit<PrayerTopic, 'id' | 'updatedAt'>;
+export type CreatePrayerTopicDTO = Omit<
+  PrayerTopic,
+  'id' | 'updatedAt' | 'entityType'
+>;
 
 export type UpdatePrayerTopicDTO = Partial<
-  Omit<PrayerTopic, 'id' | 'createdAt'>
+  Omit<PrayerTopic, 'id' | 'createdAt' | 'entityType'>
 >;
 
 // may want to refactor this in the future if document becomes too large.

--- a/FlockRN/types/typeGuards.ts
+++ b/FlockRN/types/typeGuards.ts
@@ -1,0 +1,38 @@
+import { Prayer, PrayerPoint, PrayerTopic } from '@/types/firebase';
+import { PrayerEntityType } from './PrayerSubtypes';
+
+export function getEntityType(obj: unknown): PrayerEntityType | null {
+  if (typeof obj === 'object' && obj !== null) {
+    if ('entityType' in obj) {
+      console.log(
+        'Found entityType:',
+        (obj as { entityType: PrayerEntityType }).entityType,
+      );
+      return (obj as { entityType: PrayerEntityType }).entityType;
+    }
+
+    // Check based on available properties
+    if ('title' in obj) {
+      return PrayerEntityType.Prayer; // Assuming 'title' means it's a Prayer
+    }
+    if ('type' in obj) {
+      return PrayerEntityType.PrayerPoint;
+    }
+    if ('journey' in obj) {
+      return PrayerEntityType.PrayerTopic;
+    }
+  }
+  return null;
+}
+
+export function isPrayer(obj: unknown): obj is Prayer {
+  return getEntityType(obj) === PrayerEntityType.Prayer;
+}
+
+export function isPrayerPoint(obj: unknown): obj is PrayerPoint {
+  return getEntityType(obj) === PrayerEntityType.PrayerPoint;
+}
+
+export function isPrayerTopic(obj: unknown): obj is PrayerTopic {
+  return getEntityType(obj) === PrayerEntityType.PrayerTopic;
+}

--- a/FlockRN/types/typeGuards.ts
+++ b/FlockRN/types/typeGuards.ts
@@ -1,18 +1,14 @@
 import { Prayer, PrayerPoint, PrayerTopic } from '@/types/firebase';
 import { PrayerEntityType } from './PrayerSubtypes';
 
-export function getEntityType(obj: unknown): PrayerEntityType | null {
+export function getEntityType(obj: unknown): PrayerEntityType | undefined {
   if (typeof obj === 'object' && obj !== null) {
-    if ('entityType' in obj) {
-      console.log(
-        'Found entityType:',
-        (obj as { entityType: PrayerEntityType }).entityType,
-      );
+    if ('entityType' in obj && obj.entityType !== undefined) {
       return (obj as { entityType: PrayerEntityType }).entityType;
     }
 
     // Check based on available properties
-    if ('title' in obj) {
+    if (!('title' in obj)) {
       return PrayerEntityType.Prayer; // Assuming 'title' means it's a Prayer
     }
     if ('type' in obj) {
@@ -22,7 +18,9 @@ export function getEntityType(obj: unknown): PrayerEntityType | null {
       return PrayerEntityType.PrayerTopic;
     }
   }
-  return null;
+
+  // Default return for unhandled cases
+  return undefined;
 }
 
 export function isPrayer(obj: unknown): obj is Prayer {


### PR DESCRIPTION
Added services for adding prayer topics:
- Create
- Read

Updated entity types for 'prayer' vs. 'prayer point' vs 'prayer topic':
- Helps identify the type of prayer when loading to reusable components

To do:
- Update
- Delete