### PR TITLE
fix/prevent-same-id-from-being-fetched-by-findSimilarPrayers

### DIFF
--- a/FirebaseFunctions/functions/_tests_/vectorFunctions.test.js
+++ b/FirebaseFunctions/functions/_tests_/vectorFunctions.test.js
@@ -11,6 +11,7 @@ async function testFindSimilarPrayers() {
 
   const request = {
     data: {
+      sourcePrayerId: '12345', // test prayer document
       queryEmbedding: [-0.03835538, 0.0023366269, -0.046881247],
       topK: 5,
       userId: testUid,

--- a/FirebaseFunctions/functions/vectorFunctions.js
+++ b/FirebaseFunctions/functions/vectorFunctions.js
@@ -73,7 +73,9 @@ export const getVectorEmbeddings = functions.https.onRequest(
 
 export const findSimilarPrayersV2 = functions.https.onCall(
   async (request) => {
-    const { queryEmbedding, topK, userId } = request.data;
+    const { sourcePrayerId, queryEmbedding, topK, userId } = request.data;
+    // mandatory: queryEmbedding, topK, userId
+    // optional: sourcePrayerID
 
     // Check if the function is called by an authenticated user
     if (!request.auth) {
@@ -123,7 +125,15 @@ export const findSimilarPrayersV2 = functions.https.onCall(
         ...doc.data(),
       }));
       
-      const prayerPointsAndTopics = [...prayerPoints, ...prayerTopics];
+      let prayerPointsAndTopics = [...prayerPoints, ...prayerTopics];
+
+      // Only filter if sourcePrayerId is provided. On new prayer creation, this will be null.
+      // After prayer is created, this is to prevent the prayer from being compared to itself.
+      if (sourcePrayerId) {
+        prayerPointsAndTopics = prayerPointsAndTopics.filter(
+          (prayer) => prayer.id !== sourcePrayerId
+        );
+      }
 
       if (prayerPointsAndTopics.length === 0) {
         console.log('No prayer points or topics found');

--- a/FlockRN/app/(tabs)/(prayers)/(createPrayerPoint)/createPrayerPoint.tsx
+++ b/FlockRN/app/(tabs)/(prayers)/(createPrayerPoint)/createPrayerPoint.tsx
@@ -130,19 +130,24 @@ export default function PrayerPointMetadataScreen() {
     }
 
     try {
+      const sourcePrayerId = isEditMode ? updatedPrayerPoint.id : undefined;
+
       const similarPrayers = await prayerService.findRelatedPrayers(
         embedding,
-        user.uid,
+        user?.uid,
+        sourcePrayerId,
       );
       setSimilarPrayerPoints(similarPrayers);
     } catch (error) {
       console.error('Error finding similar prayers:', error);
     }
   }, [
-    openAiService,
     updatedPrayerPoint.title,
     updatedPrayerPoint.content,
-    user?.uid,
+    updatedPrayerPoint.id,
+    openAiService,
+    user.uid,
+    isEditMode,
   ]);
 
   useEffect(() => {

--- a/FlockRN/services/prayer/prayerService.ts
+++ b/FlockRN/services/prayer/prayerService.ts
@@ -556,6 +556,7 @@ class PrayerService {
   async findRelatedPrayers(
     embedding: number[],
     userId: string,
+    sourcePrayerId?: string,
   ): Promise<(Partial<PrayerPoint> | Partial<PrayerTopic>)[] | []> {
     try {
       const functions = getFunctions(getApp());
@@ -565,6 +566,7 @@ class PrayerService {
         'findSimilarPrayersV2',
       );
       const result = await findSimilarPrayers({
+        ...(sourcePrayerId && { sourcePrayerId }),
         queryEmbedding: embedding,
         topK: 5,
         userId: userId,


### PR DESCRIPTION
Fixed an issue where the same id was being fetched from similar prayers on edit.
- Added sourcePrayerId as an optional parameter. This only applies after a prayer point has already been created.